### PR TITLE
SELC-2897 Add missing tax code in case of instituation type is diffre…

### DIFF
--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -376,7 +376,7 @@ export default function StepOnboardingFormData({
       {
         method: 'HEAD',
         params: {
-          taxCode: externalInstitutionId,
+          taxCode: institutionType === 'PA' ? externalInstitutionId : formik.values?.taxCode,
           productId,
           verifyType: 'EXTERNAL',
           vatNumber: stepHistoryState.isTaxCodeEquals2PIVA


### PR DESCRIPTION

#### List of Changes

Add misssing tax code in verify vat number API for institution type diffrent than PA

#### Motivation and Context

In case the institution type is diffrent form PA the tax code is not avaible until the user compiles the form and the api was sending missing query param taxCode

#### How Has This Been Tested?

Run application locally and test with real api call

#### Screenshots (if appropriate):

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.