### PR TITLE
SELC-2897 Added API call in order to verify registered vatNumber in prod-fd

### DIFF
--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -376,7 +376,7 @@ export default function StepOnboardingFormData({
       {
         method: 'HEAD',
         params: {
-          taxCode: externalInstitutionId,
+          taxCode: institutionType === 'PA' ? externalInstitutionId : formik.values?.taxCode,
           productId,
           verifyType: 'EXTERNAL',
           vatNumber: stepHistoryState.isTaxCodeEquals2PIVA

--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -1,13 +1,14 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 /* eslint-disable complexity */
 
-import { Box } from '@mui/system';
-import { Grid, Typography, TextField } from '@mui/material';
-import { useFormik } from 'formik';
-import { useTranslation } from 'react-i18next';
-import { useContext, useEffect, useState } from 'react';
+import { Grid, TextField, Typography } from '@mui/material';
+import { Box, styled } from '@mui/system';
 import { AxiosResponse } from 'axios';
-import { styled } from '@mui/system';
+import { useFormik } from 'formik';
+import { useContext, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { uniqueId } from 'lodash';
+import { trackEvent } from '@pagopa/selfcare-common-frontend/services/analyticsService';
 import {
   InstitutionType,
   Party,
@@ -15,21 +16,21 @@ import {
   RequestOutcomeMessage,
   StepperStepComponentProps,
 } from '../../../types';
-import { OnboardingStepActions } from '../OnboardingStepActions';
-import { useHistoryState } from '../useHistoryState';
-import { MessageNoAction } from '../MessageNoAction';
-import { OnboardingFormData } from '../../model/OnboardingFormData';
-import PersonalAndBillingDataSection from '../onboardingFormData/PersonalAndBillingDataSection';
-import DpoSection from '../onboardingFormData/DpoSection';
-import GeoTaxonomySection from '../onboardingFormData/taxonomy/GeoTaxonomySection';
-import GeoTaxSessionModal from '../onboardingFormData/taxonomy/GeoTaxSessionModal';
-import { GeographicTaxonomy, nationalValue } from '../../model/GeographicTaxonomies';
 import { fetchWithLogs } from '../../lib/api-utils';
 import { UserContext } from '../../lib/context';
 import { getFetchOutcome } from '../../lib/error-utils';
-import { ENV } from '../../utils/env';
 import { AooData } from '../../model/AooData';
+import { GeographicTaxonomy, nationalValue } from '../../model/GeographicTaxonomies';
+import { OnboardingFormData } from '../../model/OnboardingFormData';
 import { UoData } from '../../model/UoModel';
+import { ENV } from '../../utils/env';
+import { MessageNoAction } from '../MessageNoAction';
+import { OnboardingStepActions } from '../OnboardingStepActions';
+import DpoSection from '../onboardingFormData/DpoSection';
+import PersonalAndBillingDataSection from '../onboardingFormData/PersonalAndBillingDataSection';
+import GeoTaxSessionModal from '../onboardingFormData/taxonomy/GeoTaxSessionModal';
+import GeoTaxonomySection from '../onboardingFormData/taxonomy/GeoTaxonomySection';
+import { useHistoryState } from '../useHistoryState';
 
 const mailPECRegexp = new RegExp('^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,5}$');
 const fiscalAndVatCodeRegexp = new RegExp(
@@ -95,10 +96,12 @@ export default function StepOnboardingFormData({
     institutionType !== 'PT' &&
     (productId === 'prod-io' || productId === 'prod-io-sign');
   const isProdIoSign = productId === 'prod-io-sign';
+  const isProdFideiussioni = productId === 'prod-fd';
   const aooCode = aooSelected?.codiceUniAoo;
   const uoCode = uoSelected?.codiceUniUo;
   const [openModifyModal, setOpenModifyModal] = useState<boolean>(false);
   const [openAddModal, setOpenAddModal] = useState<boolean>(false);
+  const [isVatRegistrated, setIsVatRegistrated] = useState<boolean>(false);
   const { setRequiredLogin } = useContext(UserContext);
 
   const [previousGeotaxononomies, setPreviousGeotaxononomies] = useState<Array<GeographicTaxonomy>>(
@@ -154,7 +157,7 @@ export default function StepOnboardingFormData({
 
   useEffect(() => {
     void formik.validateForm();
-  }, [stepHistoryState.isTaxCodeEquals2PIVA]);
+  }, [stepHistoryState.isTaxCodeEquals2PIVA, isVatRegistrated]);
 
   const saveHistoryState = () => {
     setStepHistoryState(stepHistoryState);
@@ -275,6 +278,8 @@ export default function StepOnboardingFormData({
               stepHistoryState.isTaxCodeEquals2PIVA &&
               !fiscalAndVatCodeRegexp.test(values.taxCode)
             ? t('onboardingFormData.billingDataSection.invalidVatNumber')
+            : isVatRegistrated
+            ? t('onboardingFormData.billingDataSection.vatNumberAlreadyRegistered')
             : undefined,
         digitalAddress: !values.digitalAddress
           ? requiredError
@@ -362,6 +367,36 @@ export default function StepOnboardingFormData({
     },
   });
 
+  const verifyVatNumber = async () => {
+    const requestId = uniqueId('verify-onboarding-vatnumber');
+    const onboardingStatus = await fetchWithLogs(
+      {
+        endpoint: 'VERIFY_ONBOARDED_VAT_NUMBER',
+      },
+      {
+        method: 'HEAD',
+        params: {
+          taxCode: externalInstitutionId,
+          productId,
+          verifyType: 'EXTERNAL',
+          vatNumber: stepHistoryState.isTaxCodeEquals2PIVA
+            ? formik.values.taxCode
+            : formik.values.vatNumber,
+        },
+      },
+      () => setRequiredLogin(true)
+    );
+
+    const restOutcome = getFetchOutcome(onboardingStatus);
+
+    if (restOutcome === 'success') {
+      setIsVatRegistrated(true);
+      trackEvent('VERIFY_ONBOARDED_VAT_NUMBER', { request_id: requestId });
+    } else {
+      setIsVatRegistrated(false);
+    }
+  };
+
   useEffect(() => {
     if (
       !stepHistoryState.isTaxCodeEquals2PIVA &&
@@ -380,6 +415,17 @@ export default function StepOnboardingFormData({
       });
     }
   }, [formik.values.taxCode, formik.values.vatNumber]);
+
+  useEffect(() => {
+    if (
+      (isProdFideiussioni && formik.values.vatNumber.length === 11) ||
+      (isProdFideiussioni &&
+        stepHistoryState.isTaxCodeEquals2PIVA &&
+        formik.values.taxCode.length === 11)
+    ) {
+      void verifyVatNumber();
+    }
+  }, [formik.values.vatNumber, stepHistoryState.isTaxCodeEquals2PIVA]);
 
   const baseTextFieldProps = (
     field: keyof OnboardingFormData,

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -401,6 +401,11 @@ const mockedProducts: Array<Product> = [
     title: 'Carta Giovani',
     status: statusActive,
   },
+  {
+    id: 'prod-fd',
+    title: 'Fideiussioni',
+    status: statusActive,
+  },
 ];
 
 const mockedResponseError = {
@@ -515,6 +520,7 @@ export async function mockFetch(
     const selectedProductInTesting = mockedProducts.find(
       (p) => p.id === endpointParams.productId && p.status === 'TESTING'
     );
+
     switch (endpointParams.externalInstitutionId) {
       case 'infoError':
         return genericError;
@@ -553,6 +559,7 @@ export async function mockFetch(
           );
         }
     }
+
     if (selectedProductInTesting) {
       return notAllowedError;
     }
@@ -562,6 +569,22 @@ export async function mockFetch(
         response: { data: '', status: 400, statusText: 'Bad Request' },
       } as AxiosError)
     );
+  }
+
+  if (endpoint === 'VERIFY_ONBOARDED_VAT_NUMBER') {
+    switch (params.vatNumber) {
+      case '12345678901':
+        return new Promise((resolve) => {
+          resolve({ data: '', status: 204, statusText: 'No Content' } as AxiosResponse);
+        });
+      case '12345678902':
+        return new Promise((resolve) => {
+          resolve({
+            isAxiosError: true,
+            response: { status: 404, statusText: 'Not Found' },
+          } as AxiosError);
+        });
+    }
   }
 
   if (endpoint === 'ONBOARDING_GET_ONBOARDING_DATA') {

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -477,6 +477,7 @@ export default {
       invalidReaField: 'Il Campo REA non è valido',
       invalidMailSupport: 'L’indirizzo email non è valido',
       invalidShareCapitalField: 'Il campo capitale sociale non è valido',
+      vatNumberAlreadyRegistered: 'La P. IVA che hai inserito è già stata registrata.',
       centralPartyLabel: 'Ente centrale',
       businessName: 'Ragione sociale',
       aooName: 'Denominazione AOO',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -49,6 +49,10 @@ export const API = {
     URL: ENV.URL_API.ONBOARDING + '/institutions/{{externalInstitutionId}}/products/{{productId}}',
   },
 
+  VERIFY_ONBOARDED_VAT_NUMBER: {
+    URL: ENV.URL_API.ONBOARDING + '/institutions/onboarding',
+  },
+
   ONBOARDING_VERIFY_PRODUCT: {
     URL: ENV.URL_API.ONBOARDING + '/product/{{productId}}',
   },


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Release in UAT environment of api call for onboarding of prod fideiussioni

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Due to product requirements, onboarding will be authorized on the selfcare portal if the VAT number entered is not registered


#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Local with mocks and integration test with BE
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.