### PR TITLE
SLEC-2897 Enable checkOrganization API call fideiussioni products

### DIFF
--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -96,7 +96,7 @@ export default function StepOnboardingFormData({
     institutionType !== 'PT' &&
     (productId === 'prod-io' || productId === 'prod-io-sign');
   const isProdIoSign = productId === 'prod-io-sign';
-  const isProdFideiussioni = productId === 'prod-fd';
+  const isProdFideiussioni = productId?.startsWith('prod-fd') ?? false;
   const aooCode = aooSelected?.codiceUniAoo;
   const uoCode = uoSelected?.codiceUniUo;
   const [openModifyModal, setOpenModifyModal] = useState<boolean>(false);

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -406,6 +406,11 @@ const mockedProducts: Array<Product> = [
     title: 'Fideiussioni',
     status: statusActive,
   },
+  {
+    id: 'prod-fd-garantito',
+    title: 'Fideiussioni',
+    status: statusActive,
+  },
 ];
 
 const mockedResponseError = {


### PR DESCRIPTION
#### List of Changes 

Enable checkOrganization API call for all Fideiussioni products

#### Motivation and Context

New product was added "prod-fd-garantito"

#### How Has This Been Tested?

Test on dev

#### Screenshots (if appropriate):

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.