### PR TITLE
SELC-3029 PA can search only the correct entities in the API search parties

### DIFF
--- a/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
@@ -102,6 +102,9 @@ export default function AsyncAutocompleteContainer({
           limit: ENV.MAX_INSTITUTIONS_FETCH,
           page: 1,
           search: query,
+          categories:
+            institutionType === 'PA' &&
+            'C17,C16,L10,L19,L13,L2,C10,L20,L21,L22,L15,L1,C13,C5,L40,L11,L39,L46,L8,L34,L7,L35,L45,L47,L6,L12,L24,L28,L42,L36,L44,C8,C3,C7,C14,L16,C11,L33,C12,L43,C2,L38,C1,L5,L4,L31,L18,L17,S01,SA',
         },
       },
       () => setRequiredLogin(true)
@@ -126,17 +129,7 @@ export default function AsyncAutocompleteContainer({
       {
         method: 'GET',
         params: {
-          ...(prodPn
-            ? { categories: 'L6,L4,L45', origin: 'IPA' }
-            : institutionType === 'PA'
-            ? {
-                categories:
-                  'C17,C16,L10,L19,L13,L2,C10,L20,L21,L22,L15,L1,C13,C5,L40,L11,L39,L46,L8,L34,L7,L35,L45,L47,L6,L12,L24,L28,L42,L36,L44,C8,C3,C7,C14,L16,C11,L33,C12,L43,C2,L38,C1,L5,L4,L31,L18,L17,S01,SA',
-                origin: 'IPA',
-              }
-            : institutionType === 'GSP'
-            ? { categories: 'L37,SAG', origin: 'IPA' }
-            : null),
+          ...(prodPn && { categories: 'L6,L4,L45', origin: 'IPA' }),
         },
       },
       () => setRequiredLogin(true)

--- a/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
@@ -102,9 +102,9 @@ export default function AsyncAutocompleteContainer({
           limit: ENV.MAX_INSTITUTIONS_FETCH,
           page: 1,
           search: query,
-          categories:
-            institutionType === 'PA' &&
-            'C17,C16,L10,L19,L13,L2,C10,L20,L21,L22,L15,L1,C13,C5,L40,L11,L39,L46,L8,L34,L7,L35,L45,L47,L6,L12,L24,L28,L42,L36,L44,C8,C3,C7,C14,L16,C11,L33,C12,L43,C2,L38,C1,L5,L4,L31,L18,L17,S01,SA',
+          categories: prodPn
+            ? 'L6,L4,L45'
+            : 'C17,C16,L10,L19,L13,L2,C10,L20,L21,L22,L15,L1,C13,C5,L40,L11,L39,L46,L8,L34,L7,L35,L45,L47,L6,L12,L24,L28,L42,L36,L44,C8,C3,C7,C14,L16,C11,L33,C12,L43,C2,L38,C1,L5,L4,L31,L18,L17,S01,SA',
         },
       },
       () => setRequiredLogin(true)
@@ -129,7 +129,10 @@ export default function AsyncAutocompleteContainer({
       {
         method: 'GET',
         params: {
-          ...(prodPn && { categories: 'L6,L4,L45', origin: 'IPA' }),
+          origin: 'IPA',
+          categories: prodPn
+            ? 'L6,L4,L45'
+            : 'C17,C16,L10,L19,L13,L2,C10,L20,L21,L22,L15,L1,C13,C5,L40,L11,L39,L46,L8,L34,L7,L35,L45,L47,L6,L12,L24,L28,L42,L36,L44,C8,C3,C7,C14,L16,C11,L33,C12,L43,C2,L38,C1,L5,L4,L31,L18,L17,S01,SA',
         },
       },
       () => setRequiredLogin(true)

--- a/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
@@ -125,7 +125,19 @@ export default function AsyncAutocompleteContainer({
       { endpoint: 'ONBOARDING_GET_PARTY_FROM_CF', endpointParams: { id: query } },
       {
         method: 'GET',
-        params: { ...(prodPn && { categories: 'L6,L4,L45', origin: 'IPA' }) },
+        params: {
+          ...(prodPn
+            ? { categories: 'L6,L4,L45', origin: 'IPA' }
+            : institutionType === 'PA'
+            ? {
+                categories:
+                  'C17,C16,L10,L19,L13,L2,C10,L20,L21,L22,L15,L1,C13,C5,L40,L11,L39,L46,L8,L34,L7,L35,L45,L47,L6,L12,L24,L28,L42,L36,L44,C8,C3,C7,C14,L16,C11,L33,C12,L43,C2,L38,C1,L5,L4,L31,L18,L17,S01,SA',
+                origin: 'IPA',
+              }
+            : institutionType === 'GSP'
+            ? { categories: 'L37,SAG', origin: 'IPA' }
+            : null),
+        },
       },
       () => setRequiredLogin(true)
     );

--- a/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
@@ -155,7 +155,10 @@ export default function AsyncAutocompleteContainer({
       { endpoint: 'ONBOARDING_GET_AOO_CODE_INFO', endpointParams: { codiceUniAoo: query } },
       {
         method: 'GET',
-        params: { ...(prodPn && { categories: 'L6,L4,L45', origin: 'IPA' }) },
+        params: {
+          origin: 'IPA',
+          categories: 'L6,L4,L45',
+        },
       },
       () => setRequiredLogin(true)
     );
@@ -178,7 +181,10 @@ export default function AsyncAutocompleteContainer({
       { endpoint: 'ONBOARDING_GET_UO_CODE_INFO', endpointParams: { codiceUniUo: query } },
       {
         method: 'GET',
-        params: { ...(prodPn && { categories: 'L6,L4,L45', origin: 'IPA' }) },
+        params: {
+          origin: 'IPA',
+          categories: 'L6,L4,L45',
+        },
       },
       () => setRequiredLogin(true)
     );

--- a/src/views/onboarding/__tests__/Onboarding.test.tsx
+++ b/src/views/onboarding/__tests__/Onboarding.test.tsx
@@ -179,25 +179,23 @@ test('test billingData without Support Mail', async () => {
   await executeStepBillingDataWithoutSupportMail();
 });
 
-test('test advanvced search business name', async () => {
+test('test advanced search business name', async () => {
   renderComponent('prod-interop');
   await executeStepInstitutionType('prod-interop');
   await executeAdvancedSearchForBusinessName('AGENCY X');
 });
 
-ENV.AOO_UO.SHOW_AOO_UO &&
-  test.skip('test advanvced search aoo name with product pn', async () => {
-    renderComponent('prod-pn');
-    await executeStepInstitutionType('prod-pn');
-    await executeAdvancedSearchForAoo();
-  });
+test('test advanced search aoo name with product interop', async () => {
+  renderComponent('prod-interop');
+  await executeStepInstitutionType('prod-interop');
+  await executeAdvancedSearchForAoo();
+});
 
-ENV.AOO_UO.SHOW_AOO_UO &&
-  test.skip('test advanvced search uo name with product pn', async () => {
-    renderComponent('prod-pn');
-    await executeStepInstitutionType('prod-pn');
-    await executeAdvancedSearchForUo();
-  });
+test('test advanced search uo name with product pn', async () => {
+  renderComponent('prod-interop');
+  await executeStepInstitutionType('prod-interop');
+  await executeAdvancedSearchForUo();
+});
 
 test('test label recipientCode only for institutionType is not PA', async () => {
   renderComponent('prod-io-sign');
@@ -322,6 +320,8 @@ const executeStep1 = async (partyName: string) => {
         limit: ENV.MAX_INSTITUTIONS_FETCH,
         page: 1,
         search: 'XXX',
+        categories:
+          'C17,C16,L10,L19,L13,L2,C10,L20,L21,L22,L15,L1,C13,C5,L40,L11,L39,L46,L8,L34,L7,L35,L45,L47,L6,L12,L24,L28,L42,L36,L44,C8,C3,C7,C14,L16,C11,L33,C12,L43,C2,L38,C1,L5,L4,L31,L18,L17,S01,SA',
       },
     },
     expect.any(Function)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- PA can search only the correct entities in the API search parties
- Aoo/uoo search is now enabled to search by correct categories
- Search by businessName is filtered for PA entities (the different institutionType are not shown

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This implementation permit to not show institutionType different from PA in the search

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Feature tested in DEV environment
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.