### PR TITLE
[SELC-3221] feat: Added API call for retrieve insuranceCompany from taxId + prefilled field in billingData step + adapted the submit

### DIFF
--- a/.env.development.local
+++ b/.env.development.local
@@ -17,7 +17,7 @@ REACT_APP_PAGOPA_HELP_EMAIL=assistenza@selfcare.it
 
 REACT_APP_URL_INSTITUTION_LOGO_PREFIX=https://selcdcheckoutsa.z6.web.core.windows.net/institutions/
 
-REACT_APP_MOCK_API=true
+REACT_APP_MOCK_API=false
 
 REACT_APP_ONE_TRUST_BASE_URL=https://cdn.cookielaw.org
 REACT_APP_ANALYTICS_ENABLE=false

--- a/.env.development.local
+++ b/.env.development.local
@@ -17,7 +17,7 @@ REACT_APP_PAGOPA_HELP_EMAIL=assistenza@selfcare.it
 
 REACT_APP_URL_INSTITUTION_LOGO_PREFIX=https://selcdcheckoutsa.z6.web.core.windows.net/institutions/
 
-REACT_APP_MOCK_API=false
+REACT_APP_MOCK_API=true
 
 REACT_APP_ONE_TRUST_BASE_URL=https://cdn.cookielaw.org
 REACT_APP_ANALYTICS_ENABLE=false

--- a/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
@@ -209,11 +209,17 @@ export default function AsyncAutocompleteContainer({
     setIsLoading(false);
   };
 
-  const handleSearchSaByTaxCode = async (query: string) => {
+  const contractingInsuranceFromTaxId = async (query: string) => {
     setIsLoading(true);
 
     const searchResponse = await fetchWithLogs(
-      { endpoint: 'ONBOARDING_GET_SA_PARTY_FROM_FC', endpointParams: { id: query } },
+      {
+        endpoint:
+          institutionType === 'SA'
+            ? 'ONBOARDING_GET_SA_PARTY_FROM_FC'
+            : 'ONBOARDING_GET_INSURANCE_COMPANIES_BY_TAXCODE',
+        endpointParams: institutionType === 'SA' ? { id: query } : { taxId: query },
+      },
       {
         method: 'GET',
       },
@@ -262,8 +268,8 @@ export default function AsyncAutocompleteContainer({
       if (value.length >= 3 && isBusinessNameSelected && !isTaxCodeSelected) {
         seachByInstitutionType(value, institutionType);
       } else if (isTaxCodeSelected && value.length === 11) {
-        if (institutionType === 'SA') {
-          void handleSearchSaByTaxCode(value);
+        if (institutionType === 'SA' || institutionType === 'AS') {
+          void contractingInsuranceFromTaxId(value);
         } else {
           void handleSearchByTaxCode(value);
         }

--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -338,7 +338,7 @@ export default function PersonalAndBillingDataSection({
                   400,
                   18
                 )}
-                value={formik.values.originId} // ivassCode === originId
+                value={formik.values.ivassCode}
               />
             </Grid>
           )}

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -522,7 +522,7 @@ const mockedStationResource: StationResource = {
 };
 
 const mockedInsuranceResource: InsuranceCompaniesResource = {
-  count: 0,
+  count: 3,
   items: [
     {
       address: 'addres',
@@ -530,10 +530,32 @@ const mockedInsuranceResource: InsuranceCompaniesResource = {
       digitalAddress: 'email@example.com',
       id: '12345678911',
       origin: 'IVASS',
-      originId: 'codice IVASS',
+      originId: '233DC',
       registerType: 'string',
       taxCode: '12345678911',
       workType: 'string',
+    },
+    {
+      address: 'addressd',
+      description: 'insur',
+      digitalAddress: 'email@mailtest.com',
+      id: '11987654321',
+      origin: 'IVASS',
+      originId: '2323H',
+      registerType: 'reg',
+      taxCode: '11987654321',
+      workType: 'worktype',
+    },
+    {
+      address: 'addressd54',
+      description: 'ins',
+      digitalAddress: 'email@mock.com',
+      id: '66557744831',
+      origin: 'IVASS',
+      originId: '232DC',
+      registerType: 'regG',
+      taxCode: '66557744831',
+      workType: 'worktype',
     },
   ],
 };
@@ -703,15 +725,24 @@ export async function mockFetch(
     );
   }
 
+  if (endpoint === 'ONBOARDING_GET_SA_PARTY_FROM_FC') {
+    return new Promise((resolve) =>
+      resolve({ data: mockedANACParty, status: 200, statusText: '200' } as AxiosResponse)
+    );
+  }
+
   if (endpoint === 'ONBOARDING_GET_INSURANCE_COMPANIES_BY_NAME') {
     return new Promise((resolve) =>
       resolve({ data: mockedInsuranceResource, status: 200, statusText: '200' } as AxiosResponse)
     );
   }
 
-  if (endpoint === 'ONBOARDING_GET_SA_PARTY_FROM_FC') {
+  if (endpoint === 'ONBOARDING_GET_INSURANCE_COMPANIES_BY_TAXCODE') {
+    const matchedInstitution = mockedInsuranceResource.items.find(
+      (i) => i.taxCode === endpointParams.taxId
+    );
     return new Promise((resolve) =>
-      resolve({ data: mockedANACParty, status: 200, statusText: '200' } as AxiosResponse)
+      resolve({ data: matchedInstitution, status: 200, statusText: '200' } as AxiosResponse)
     );
   }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -110,6 +110,9 @@ export const API = {
   ONBOARDING_GET_INSURANCE_COMPANIES_BY_NAME: {
     URL: ENV.URL_API.PARTY_REGISTRY_PROXY + '/insurance-companies',
   },
+  ONBOARDING_GET_INSURANCE_COMPANIES_BY_TAXCODE: {
+    URL: ENV.URL_API.PARTY_REGISTRY_PROXY + '/insurance-companies/{{taxId}}',
+  },
 };
 
 export const USER_ROLE_LABEL = {

--- a/src/views/onboarding/Onboarding.tsx
+++ b/src/views/onboarding/Onboarding.tsx
@@ -280,6 +280,7 @@ function OnboardingComponent({ productId }: { productId: string }) {
       vatNumber: '',
       zipCode: aooResult ? aooResult.CAP : uoResult ? uoResult.CAP : party.zipCode,
       geographicTaxonomies: onboardingFormData?.geographicTaxonomies as Array<GeographicTaxonomy>,
+      ivassCode: institutionType === 'AS' ? party.originId : undefined,
     });
     forwardWithData(newFormData);
     trackEvent('ONBOARDING_PARTY_SELECTION', {
@@ -445,6 +446,7 @@ function OnboardingComponent({ productId }: { productId: string }) {
               ? companyInformationsDto2pspDataRequest(onboardingFormData as OnboardingFormData)
               : undefined,
           institutionType,
+          ivassCode: onboardingFormData?.ivassCode,
           geographicTaxonomies: ENV.GEOTAXONOMY.SHOW_GEOTAXONOMY //
             ? onboardingFormData?.geographicTaxonomies?.map((gt) =>
                 onboardedInstitutionInfo2geographicTaxonomy(gt)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Added API call for retrieve insuranceCompany from taxId
- Prefilled field in billingData step
- Adapted the submit in order to send IvassCode if present

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In order to allow the organization to also search via tax code, ensure that the IvassCode field is pre-populated in the next form and that the information is then sent via submit once adhesion is concluded

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Local and aiming envinroment DEV data

<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.