### PR TITLE
[SELC-3239] fix:  send taxCode + aoo/uo code to getOboarding api parms

### DIFF
--- a/src/components/steps/StepOnboardingData.tsx
+++ b/src/components/steps/StepOnboardingData.tsx
@@ -16,11 +16,15 @@ import { fetchWithLogs } from '../../lib/api-utils';
 import { getFetchOutcome } from '../../lib/error-utils';
 import { unregisterUnloadEvent } from '../../utils/unloadEvent-utils';
 import { ENV } from '../../utils/env';
+import { AooData } from '../../model/AooData';
+import { UoData } from '../../model/UoModel';
 
 type Props = StepperStepComponentProps & {
   externalInstitutionId: string;
   productId: string;
   institutionType?: InstitutionType;
+  aooSelected?: AooData;
+  uoSelected?: UoData;
 };
 
 const genericError: RequestOutcomeMessage = {
@@ -48,7 +52,15 @@ const genericError: RequestOutcomeMessage = {
   ],
 };
 
-function StepOnboardingData({ forward, externalInstitutionId, productId, institutionType }: Props) {
+// eslint-disable-next-line sonarjs/cognitive-complexity
+function StepOnboardingData({
+  forward,
+  externalInstitutionId,
+  productId,
+  institutionType,
+  aooSelected,
+  uoSelected,
+}: Props) {
   const { t } = useTranslation();
 
   const [loading, setLoading] = useState(true);
@@ -63,7 +75,11 @@ function StepOnboardingData({ forward, externalInstitutionId, productId, institu
       {
         endpoint: 'ONBOARDING_GET_ONBOARDING_DATA',
         endpointParams: {
-          externalInstitutionId,
+          externalInstitutionId: aooSelected
+            ? `${externalInstitutionId}_${aooSelected.codiceUniAoo}`
+            : uoSelected
+            ? `${externalInstitutionId}_${uoSelected.codiceUniUo}`
+            : externalInstitutionId,
           productId,
         },
       },

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -751,11 +751,11 @@ export async function mockFetch(
           return notFound;
         }
       // Use case for test aoo
-      case 'aooId':
+      case '92078570527':
         if (params.subunitCode) {
-          return noContent;
-        } else {
           return notFound;
+        } else {
+          return noContent;
         }
       default:
         if (params.productId !== 'prod-io') {
@@ -797,6 +797,11 @@ export async function mockFetch(
     const onboardingData = mockedOnboardingData.find(
       (od) => od.institution.billingData.taxCode === endpointParams.externalInstitutionId
     );
+    if (endpointParams.externalInstitutionId === '92078570527') {
+      return new Promise((resolve) =>
+        resolve({ data: onboardingData, status: 200, statusText: '200' } as AxiosResponse)
+      );
+    }
     if (onboardingData) {
       return new Promise((resolve) =>
         resolve({

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -312,14 +312,14 @@ const mockedGeoTaxonomy = [
 ];
 
 const mockedAooCode: AooData = {
-  codAoo: 'ND',
+  codAoo: 'A356E00',
   codiceFiscaleEnte: '92078570527',
   codiceIpa: '03YBQ4C7',
   codiceUniAoo: 'A356E00',
   denominazioneAoo: 'Denominazione Aoo Test',
   denominazioneEnte: 'Comune Test',
   id: 'A356E00',
-  mail1: 'test.it',
+  mail1: 'test@test.it',
   origin: 'IPA',
   CAP: '53100',
   codiceCatastaleComune: 'I726',
@@ -418,6 +418,37 @@ const mockedOnboardingData: Array<InstitutionOnboardingInfoResource> = [
         digitalAddress: 'comune.bollate@pec.it',
         taxCode: 'BBBBBB11A11A123K',
         vatNumber: '12345678901',
+        recipientCode: 'M2UHYR1',
+        geographicTaxonomies: [
+          {
+            code: '058091',
+            desc: 'Firenze - Comune',
+          },
+        ],
+        supportEmail: 'comune.bollate@pec.it',
+      },
+      institutionType: 'PA',
+      origin: 'IPA',
+      assistanceContacts: {
+        supportEmail: 'a@a.it',
+      },
+      companyInformations: {
+        businessRegisterPlace: 'register Place test',
+        rea: 'RM-123456',
+        shareCapital: '123456',
+      },
+    },
+  },
+  {
+    institution: {
+      id: '92078570527',
+      billingData: {
+        businessName: 'Comune di Bollate AOO',
+        registeredOffice: 'Bollate, Piazza Colonna 370',
+        zipCode: '20021',
+        digitalAddress: 'comune.bollate@pec.it',
+        taxCode: '92078570527',
+        vatNumber: '92078570523',
         recipientCode: 'M2UHYR1',
         geographicTaxonomies: [
           {

--- a/src/views/onboarding/Onboarding.tsx
+++ b/src/views/onboarding/Onboarding.tsx
@@ -637,6 +637,8 @@ function OnboardingComponent({ productId }: { productId: string }) {
           productId,
           institutionType,
           forward: forwardWithOnboardingData,
+          aooSelected,
+          uoSelected,
         }),
     },
     {

--- a/src/views/onboarding/__tests__/Onboarding.test.tsx
+++ b/src/views/onboarding/__tests__/Onboarding.test.tsx
@@ -197,7 +197,7 @@ test.skip('test billingData without Support Mail', async () => {
   await executeStepBillingDataWithoutSupportMail();
 });
 
-test('test advanced search A00 name with product interop', async () => {
+test('test complete onboarding AOO with product interop', async () => {
   renderComponent('prod-interop');
   await executeStepInstitutionType('prod-interop');
   await executeAdvancedSearchForAoo();
@@ -425,7 +425,7 @@ const executeAdvancedSearchForAoo = async () => {
   const input = selectWrapper?.firstChild as HTMLElement;
   fireEvent.keyDown(input, { keyCode: 40 });
 
-  const option = (await document.getElementById('aooCode')) as HTMLElement;
+  const option = document.getElementById('aooCode') as HTMLElement;
   fireEvent.click(option);
   expect(inputPartyName).toBeTruthy();
   fireEvent.change(inputPartyName, { target: { value: 'A356E00' } });
@@ -441,6 +441,12 @@ const executeAdvancedSearchForAoo = async () => {
 
   fireEvent.click(confirmButton);
   await waitFor(() => expect(fetchWithLogsSpy).toBeCalledTimes(6));
+
+  const aooCode = document.getElementById('aooUniqueCode') as HTMLInputElement;
+  const aooName = document.getElementById('aooName') as HTMLInputElement;
+
+  await waitFor(() => expect(aooCode.value).toBe('A356E00'));
+  await waitFor(() => expect(aooName.value).toBe('Denominazione Aoo Test'));
 };
 
 const executeAdvancedSearchForUo = async () => {

--- a/src/views/onboarding/__tests__/Onboarding.test.tsx
+++ b/src/views/onboarding/__tests__/Onboarding.test.tsx
@@ -201,6 +201,12 @@ test('test complete onboarding AOO with product interop', async () => {
   renderComponent('prod-interop');
   await executeStepInstitutionType('prod-interop');
   await executeAdvancedSearchForAoo();
+  await executeStep2();
+  await executeStep3(true);
+  const onboardingComlpeted = await waitFor(() =>
+    screen.getByText('Richiesta di adesione inviata')
+  );
+  expect(onboardingComlpeted).toBeInTheDocument();
 });
 
 test('test label recipientCode only for institutionType is not PA', async () => {
@@ -447,6 +453,20 @@ const executeAdvancedSearchForAoo = async () => {
 
   await waitFor(() => expect(aooCode.value).toBe('A356E00'));
   await waitFor(() => expect(aooName.value).toBe('Denominazione Aoo Test'));
+
+  const isTaxCodeEquals2PIVA = document.getElementById('onboardingFormData');
+  expect(isTaxCodeEquals2PIVA).toBeTruthy();
+
+  const vatNumber = document.getElementById('vatNumber') as HTMLInputElement;
+
+  fireEvent.change(vatNumber as HTMLElement, {
+    target: { value: 'AAAAAA44D55F456K' },
+  });
+
+  const continueButton = await waitFor(() => screen.getByRole('button', { name: 'Continua' }));
+  expect(continueButton).toBeEnabled();
+
+  fireEvent.click(continueButton);
 };
 
 const executeAdvancedSearchForUo = async () => {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
When makeing get onboarding api call send taxCode_Aoo/uocode as externalId in params 
<!--- Describe your changes in detail -->

#### Motivation and Context
If the central institution was onboarded it would find it by taxId and return 200. Need to send aoo/uo code as well if we want to know if the aoo is onbarded.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit tests and by movked uat enviroment.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.