### PR TITLE
[SELC-3336] feat: Called geotaxonomy API in order to retrieve countries, created a map with what is needed and kept only the municipalities

### DIFF
--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -85,6 +85,23 @@ export default function StepOnboardingFormData({
   aooSelected,
   uoSelected,
 }: Props) {
+  const { t } = useTranslation();
+  const { setRequiredLogin } = useContext(UserContext);
+
+  const [openModifyModal, setOpenModifyModal] = useState<boolean>(false);
+  const [openAddModal, setOpenAddModal] = useState<boolean>(false);
+  const [isVatRegistrated, setIsVatRegistrated] = useState<boolean>(false);
+  const [previousGeotaxononomies, setPreviousGeotaxononomies] = useState<Array<GeographicTaxonomy>>(
+    []
+  );
+
+  const [stepHistoryState, setStepHistoryState, setStepHistoryStateHistory] =
+    useHistoryState<StepBillingDataHistoryState>('onboardingFormData', {
+      externalInstitutionId,
+      isTaxCodeEquals2PIVA:
+        !!initialFormData.vatNumber && initialFormData.taxCode === initialFormData.vatNumber,
+    });
+
   const requiredError = 'Required';
 
   const institutionAvoidGeotax = ['PT', 'SA', 'AS'].includes(institutionType);
@@ -103,23 +120,6 @@ export default function StepOnboardingFormData({
   const isProdFideiussioni = productId?.startsWith('prod-fd') ?? false;
   const aooCode = aooSelected?.codiceUniAoo;
   const uoCode = uoSelected?.codiceUniUo;
-  const [openModifyModal, setOpenModifyModal] = useState<boolean>(false);
-  const [openAddModal, setOpenAddModal] = useState<boolean>(false);
-  const [isVatRegistrated, setIsVatRegistrated] = useState<boolean>(false);
-  const { setRequiredLogin } = useContext(UserContext);
-
-  const [previousGeotaxononomies, setPreviousGeotaxononomies] = useState<Array<GeographicTaxonomy>>(
-    []
-  );
-
-  const { t } = useTranslation();
-
-  const [stepHistoryState, setStepHistoryState, setStepHistoryStateHistory] =
-    useHistoryState<StepBillingDataHistoryState>('onboardingFormData', {
-      externalInstitutionId,
-      isTaxCodeEquals2PIVA:
-        !!initialFormData.vatNumber && initialFormData.taxCode === initialFormData.vatNumber,
-    });
 
   const getPreviousGeotaxononomies = async () => {
     const onboardingData = await fetchWithLogs(

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -9,7 +9,7 @@ import {
   InsuranceCompaniesResource,
 } from '../../../types';
 import { BillingDataDto } from '../../model/BillingData';
-import { nationalValue } from '../../model/GeographicTaxonomies';
+import { GeographicTaxonomyResource, nationalValue } from '../../model/GeographicTaxonomies';
 import { UoData } from '../../model/UoModel';
 import { AooData } from './../../model/AooData';
 
@@ -296,18 +296,39 @@ const mockedParties = [
   ),
 ];
 
-const mockedGeoTaxonomy = [
+export const mockedGeoTaxonomy: Array<GeographicTaxonomyResource> = [
   {
     code: nationalValue,
     desc: 'ITALIA',
-    region: '12',
-    province: '058',
-    provinceAbbreviation: 'RM',
-    country: 'ITA',
-    countryAbbreviation: 'IT',
-    startDate: '1871-01-15',
-    endDate: null,
-    enable: true,
+    country_abbreviation: 'IT',
+    enabled: true,
+    istat_code: '1212343',
+    province_abbreviation: 'RM',
+    province_id: '058',
+    region_id: '12',
+    country: 'ITALY',
+  },
+  {
+    code: '2334',
+    country: '232',
+    country_abbreviation: 'IT',
+    desc: 'MILANO - PROVINCIA',
+    enabled: true,
+    province_abbreviation: 'MI',
+    province_id: '334',
+    region_id: '43',
+    istat_code: '233',
+  },
+  {
+    code: '545456',
+    country: '232',
+    country_abbreviation: 'IT',
+    desc: 'MILLESIMO - COMUNE',
+    enabled: true,
+    istat_code: '2233445',
+    province_abbreviation: 'SV',
+    province_id: '433',
+    region_id: '65',
   },
 ];
 

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -495,6 +495,7 @@ export default {
       fullLegalAddress: 'Indirizzo e numero civico della sede legale',
       zipCode: 'CAP',
       city: 'Città',
+      noResult: 'Nessun risultato',
       province: 'Provincia',
       digitalAddress: 'Indirizzo PEC',
       taxCodeEquals2PIVAdescription: 'La Partita IVA coincide con il Codice Fiscale',

--- a/src/model/Country.ts
+++ b/src/model/Country.ts
@@ -1,0 +1,7 @@
+export type Country = {
+  code: string;
+  county: string;
+  desc: string;
+  country: string;
+  province: string;
+};

--- a/src/model/GeographicTaxonomies.ts
+++ b/src/model/GeographicTaxonomies.ts
@@ -1,3 +1,15 @@
+export type GeographicTaxonomyResource = {
+  code: string;
+  country: string;
+  country_abbreviation: string;
+  desc: string;
+  enabled: boolean;
+  istat_code: string;
+  province_abbreviation: string;
+  province_id: string;
+  region_id: string;
+};
+
 export type GeographicTaxonomy = {
   code: string;
   desc: string;


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Called geotaxonomy API in order to retrieve countries, created a map with what is needed and kept only the municipalities

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
To populate the Autocomplete component with the cities, the Geotaxonomies API call was invoked where only the municipalities were kept and the description was cleaned by removing "- MUNICIPALITY".

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Aiming dev environment, the search works and the selection is saved.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.