### PR TITLE
[SELC-3292] fix: Used taxCode instead of externalInstitutionId

### DIFF
--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -7,8 +7,6 @@ import { AxiosResponse } from 'axios';
 import { useFormik } from 'formik';
 import { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { uniqueId } from 'lodash';
-import { trackEvent } from '@pagopa/selfcare-common-frontend/services/analyticsService';
 import { emailRegexp } from '@pagopa/selfcare-common-frontend/utils/constants';
 import {
   InstitutionType,
@@ -386,7 +384,6 @@ export default function StepOnboardingFormData({
   });
 
   const verifyVatNumber = async () => {
-    const requestId = uniqueId('verify-onboarding-vatnumber');
     const onboardingStatus = await fetchWithLogs(
       {
         endpoint: 'VERIFY_ONBOARDING',
@@ -409,7 +406,6 @@ export default function StepOnboardingFormData({
 
     if (restOutcome === 'success') {
       setIsVatRegistrated(true);
-      trackEvent('VERIFY_ONBOARDING', { request_id: requestId });
     } else {
       setIsVatRegistrated(false);
     }

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -256,9 +256,9 @@ const mockedParties = [
     '775644',
     'Comune di Gessate',
     'logo',
+    '33445673210',
     'address4',
     'b@bb.com',
-    '33445673210',
     '00022'
   ),
   createPartyEntity(
@@ -763,15 +763,15 @@ export async function mockFetch(
 
   if (endpoint === 'VERIFY_ONBOARDING') {
     switch (params.taxCode) {
-      case 'infoError':
-      case 'externalId4':
+      case '99999999999':
+      case '33445673210':
         return genericError;
-      case 'notAllowed':
+      case '44444444444':
         return notAllowedError;
       case 'onboarded_externalId':
-      case 'onboarded':
+      case '22222222222':
         return noContent;
-      case 'pending':
+      case '33333333333':
         return notFound;
       // Use case for test not base adhesion
       case 'externalId3':

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -764,7 +764,7 @@ export async function mockFetch(
   if (endpoint === 'VERIFY_ONBOARDING') {
     switch (params.taxCode) {
       case '99999999999':
-      case '33445673210':
+      case 'externalId4':
         return genericError;
       case '44444444444':
         return notAllowedError;

--- a/src/views/onboarding/Onboarding.tsx
+++ b/src/views/onboarding/Onboarding.tsx
@@ -301,7 +301,7 @@ function OnboardingComponent({ productId }: { productId: string }) {
     });
 
     setOnboardingFormData(newOnboardingFormData);
-    if (institutionType === 'PSP' || institutionType !== 'PA') {
+    if (institutionType !== 'PA') {
       // TODO: fix when party registry proxy will return externalInstitutionId
       setExternalInstitutionId(newOnboardingFormData.taxCode);
 
@@ -313,7 +313,7 @@ function OnboardingComponent({ productId }: { productId: string }) {
           {
             method: 'HEAD',
             params: {
-              taxCode: onboardingFormData?.taxCode,
+              taxCode: newOnboardingFormData.taxCode,
               productId,
               subunitCode: aooSelected
                 ? aooSelected.codiceUniAoo

--- a/src/views/onboarding/Onboarding.tsx
+++ b/src/views/onboarding/Onboarding.tsx
@@ -313,7 +313,7 @@ function OnboardingComponent({ productId }: { productId: string }) {
           {
             method: 'HEAD',
             params: {
-              taxCode: externalInstitutionId,
+              taxCode: onboardingFormData?.taxCode,
               productId,
               subunitCode: aooSelected
                 ? aooSelected.codiceUniAoo

--- a/src/views/onboarding/components/OnboardingStep1_5.tsx
+++ b/src/views/onboarding/components/OnboardingStep1_5.tsx
@@ -118,7 +118,7 @@ export function OnboardingStep1_5({
       {
         method: 'HEAD',
         params: {
-          taxCode: externalInstitutionId,
+          taxCode: selectedParty?.taxCode,
           productId,
           subunitCode: aooSelected
             ? aooSelected.codiceUniAoo


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Used taxCode instead of externalInstitutionId

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In order to resolve the error of API call for institution that not have certificated data: because in the case of an institution not selected from the list, the data used previously (externalInstitutionId) will be undefined. For linearity, it has also been replaced in the other calls. Also removed an unnecessary condition constraint.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Aiming DEV environment data, the API call responds as expected: 
- 400 or 404 in the case of a non-onboarded institution
- 204 in the case of an already onboarded institution
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.