### PR TITLE
[SELC-3338] fix: InstitutionLocationData will not be sent in case of non-existence

### DIFF
--- a/src/views/onboarding/Onboarding.tsx
+++ b/src/views/onboarding/Onboarding.tsx
@@ -301,7 +301,7 @@ function OnboardingComponent({ productId }: { productId: string }) {
     });
 
     setOnboardingFormData(newOnboardingFormData);
-    if (institutionType === 'PSP' || institutionType !== 'PA') {
+    if (institutionType !== 'PA') {
       // TODO: fix when party registry proxy will return externalInstitutionId
       setExternalInstitutionId(newOnboardingFormData.taxCode);
 
@@ -313,7 +313,7 @@ function OnboardingComponent({ productId }: { productId: string }) {
           {
             method: 'HEAD',
             params: {
-              taxCode: externalInstitutionId,
+              taxCode: newOnboardingFormData.taxCode,
               productId,
               subunitCode: aooSelected
                 ? aooSelected.codiceUniAoo
@@ -462,11 +462,14 @@ function OnboardingComponent({ productId }: { productId: string }) {
                 onboardedInstitutionInfo2geographicTaxonomy(gt)
               )
             : [],
-          institutionLocationData: {
-            country: onboardingFormData?.country,
-            county: onboardingFormData?.county,
-            city: onboardingFormData?.city,
-          },
+          institutionLocationData:
+            institutionType !== 'PA' && origin !== 'IPA'
+              ? {
+                  country: onboardingFormData?.country,
+                  county: onboardingFormData?.county,
+                  city: onboardingFormData?.city,
+                }
+              : undefined,
           origin,
           users: users.map((u) => ({
             ...u,

--- a/src/views/onboarding/__tests__/Onboarding.test.tsx
+++ b/src/views/onboarding/__tests__/Onboarding.test.tsx
@@ -1215,11 +1215,7 @@ const verifySubmit = async (productId = 'prod-idpay') => {
           geographicTaxonomies: ENV.GEOTAXONOMY.SHOW_GEOTAXONOMY
             ? [{ code: nationalValue, desc: 'ITALIA' }]
             : [],
-          institutionLocationData: {
-            country: undefined,
-            county: undefined,
-            city: undefined,
-          },
+          institutionLocationData: undefined,
           assistanceContacts: { supportEmail: 'a@a.it' },
           productId,
           subunitCode: undefined,


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
InstitutionLocationData will not be sent in case of non-existence

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
For institutions not present in IPA and for institutions not present on the IPA and not belonging to the PAs, it is necessary not to send the object (previously it was sent in the payload anyway and being empty, it was translated as an object with its keys set to null)

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Test in DEV environment, now for institution not present on the IPA and not PA, in the submit payload the institutionLocation data will not be sent
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.