### PR TITLE
[SELC-3335] fix: Fixed formik validation for origin different from ipa

### DIFF
--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -283,8 +283,12 @@ export default function StepOnboardingFormData({
             : isVatRegistrated
             ? t('onboardingFormData.billingDataSection.vatNumberAlreadyRegistered')
             : undefined,
-        city: institutionType !== 'PA' && !values.city ? requiredError : undefined,
-        county: institutionType !== 'PA' && !values.county ? requiredError : undefined,
+        city:
+          institutionType !== 'PA' && origin !== 'IPA' && !values.city ? requiredError : undefined,
+        county:
+          institutionType !== 'PA' && origin !== 'IPA' && !values.county
+            ? requiredError
+            : undefined,
         ivassCode:
           isInsuranceCompany && !values.ivassCode
             ? requiredError


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Fixed formik validation for origin different from ipa

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The bug consisted in the fact that for institutionTypes other than PA but with origin coming from IPA, the validation of the completeness of the form was not successful and the continua remained disabled. A missing check has been added to make this happen.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Aiming DEV environment, the validation of the form with data institution for institutionTypes other than PA but with origin coming from IPA goes success and confirm button is enabled, then an onboarding has been tested and is successful, with the expected payload
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.