### PR TITLE
[SELC-3362] feat: Show fields city and province precompiled and disabled

### DIFF
--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -6,7 +6,7 @@ import Checkbox from '@mui/material/Checkbox';
 import { theme } from '@pagopa/mui-italia';
 import Autocomplete from '@mui/material/Autocomplete';
 import { AxiosResponse } from 'axios';
-import { InstitutionType, StepperStepComponentProps } from '../../../types';
+import { InstitutionType, Party, StepperStepComponentProps } from '../../../types';
 import { OnboardingFormData } from '../../model/OnboardingFormData';
 import { StepBillingDataHistoryState } from '../steps/StepOnboardingFormData';
 import { AooData } from '../../model/AooData';
@@ -16,6 +16,7 @@ import { getFetchOutcome } from '../../lib/error-utils';
 import { GeographicTaxonomyResource } from '../../model/GeographicTaxonomies';
 import { UserContext } from '../../lib/context';
 import { InstitutionLocationData } from '../../model/InstitutionLocationData';
+import { formatCity } from '../../utils/formatting-utils';
 import NumberDecimalFormat from './NumberDecimalFormat';
 
 const CustomTextField = styled(TextField)({
@@ -46,6 +47,7 @@ type Props = StepperStepComponentProps & {
   aooSelected?: AooData;
   uoSelected?: UoData;
   institutionAvoidGeotax: boolean;
+  selectedParty?: Party;
 };
 
 // eslint-disable-next-line sonarjs/cognitive-complexity, complexity
@@ -61,6 +63,7 @@ export default function PersonalAndBillingDataSection({
   aooSelected,
   uoSelected,
   institutionAvoidGeotax,
+  selectedParty,
 }: Props) {
   const { t } = useTranslation();
   const { setRequiredLogin } = useContext(UserContext);
@@ -89,8 +92,8 @@ export default function PersonalAndBillingDataSection({
       formik.setFieldValue('city', institutionLocationData.city);
       setShrinkCounty(true);
     } else {
-      formik.setFieldValue('country', undefined);
-      formik.setFieldValue('county', undefined);
+      formik.setFieldValue('country', '');
+      formik.setFieldValue('county', '');
       formik.setFieldValue('city', undefined);
       setShrinkCounty(false);
     }
@@ -106,6 +109,13 @@ export default function PersonalAndBillingDataSection({
   const recipientCodeVisible = !isContractingAuthority && !isTechPartner && !isInsuranceCompany;
   const requiredError = 'Required';
   const isAooUo = aooSelected || uoSelected;
+
+  useEffect(() => {
+    if (isFromIPA && selectedParty?.istat_code) {
+      void getLocationFromIstatCode(selectedParty.istat_code);
+    }
+  }, [institutionType, selectedParty]);
+
   const baseNumericFieldProps = (
     field: keyof OnboardingFormData,
     label: string,
@@ -165,13 +175,37 @@ export default function PersonalAndBillingDataSection({
         .filter((r) => r.city.includes('- COMUNE'))
         .map((r) => ({
           ...r,
-          city: r.city
-            .charAt(0)
-            .toUpperCase()
-            .concat(r.city.substring(1).toLowerCase().replace('- comune', '').trim()),
+          city: formatCity(r.city),
         }));
 
       setCountries(onlyCountries);
+    }
+  };
+
+  const getLocationFromIstatCode = async (istatCode: string) => {
+    const getLocation = await fetchWithLogs(
+      {
+        endpoint: 'ONBOARDING_GET_LOCATION_BY_ISTAT_CODE',
+        endpointParams: {
+          geoTaxId: istatCode,
+        },
+      },
+      { method: 'GET' },
+      () => setRequiredLogin(true)
+    );
+    const outcome = getFetchOutcome(getLocation);
+
+    if (outcome === 'success') {
+      const result = (getLocation as AxiosResponse).data;
+      if (result) {
+        const mappedObject = {
+          code: result.code,
+          country: result.country_abbreviation,
+          county: result.province_abbreviation,
+          city: formatCity(result.desc),
+        };
+        setInstitutionLocationData(mappedObject);
+      }
     }
   };
 
@@ -286,95 +320,102 @@ export default function PersonalAndBillingDataSection({
               />
             </Grid>
           </Grid>
-          {institutionType !== 'PA' && origin !== 'IPA' && (
-            <Grid container spacing={2} pl={3} pt={3}>
-              <Grid item xs={7}>
-                <Autocomplete
-                  id="city-select"
-                  onInput={(e: any) => {
-                    const value = e.target.value as string;
-                    if (value.length >= 3) {
-                      void getCountriesFromGeotaxonomies(value);
-                    }
-                  }}
-                  onChange={(_e: any, selected: any) => {
-                    if (selected) {
-                      setShrinkCounty(true);
-                      setInstitutionLocationData(selected);
-                      formik.setFieldValue('city', selected.desc);
-                      formik.setFieldValue('county', selected.county);
-                      formik.setFieldValue('country', selected.country);
-                    } else {
-                      setShrinkCounty(false);
-                      formik.setFieldValue('county', undefined);
-                      formik.setFieldValue('country', undefined);
-                    }
-                  }}
-                  getOptionLabel={(o) => o.city}
-                  options={countries ?? []}
-                  noOptionsText={t('onboardingFormData.billingDataSection.noResult')}
-                  ListboxProps={{
-                    style: {
-                      overflow: 'visible',
-                    },
-                  }}
-                  componentsProps={{
-                    paper: {
-                      sx: {
-                        '&::-webkit-scrollbar': {
-                          width: 4,
-                        },
-                        '&::-webkit-scrollbar-track': {
-                          boxShadow: `inset 10px 10px  #E6E9F2`,
-                          marginY: '3px',
-                        },
-                        '&::-webkit-scrollbar-thumb': {
-                          backgroundColor: '#0073E6',
-                          borderRadius: '16px',
-                        },
-                        overflowY: 'auto',
-                        maxHeight: '200px',
-                        boxShadow:
-                          '0px 6px 30px 5px rgba(0, 43, 85, 0.10), 0px 16px 24px 2px rgba(0, 43, 85, 0.05), 0px 8px 10px -5px rgba(0, 43, 85, 0.10)',
+
+          <Grid container spacing={2} pl={3} pt={3}>
+            <Grid item xs={7}>
+              <Autocomplete
+                id="city-select"
+                onInput={(e: any) => {
+                  const value = e.target.value as string;
+                  if (value.length >= 3) {
+                    void getCountriesFromGeotaxonomies(value);
+                  }
+                }}
+                onChange={(_e: any, selected: any) => {
+                  if (selected) {
+                    setShrinkCounty(true);
+                    setInstitutionLocationData(selected);
+                  } else {
+                    setShrinkCounty(false);
+                    setCountries(undefined);
+                    setInstitutionLocationData(undefined);
+                  }
+                }}
+                getOptionLabel={(o) => o.city}
+                options={countries ?? []}
+                noOptionsText={t('onboardingFormData.billingDataSection.noResult')}
+                popupIcon={isFromIPA ? '' : undefined}
+                disabled={isFromIPA}
+                ListboxProps={{
+                  style: {
+                    overflow: 'visible',
+                  },
+                }}
+                componentsProps={{
+                  paper: {
+                    sx: {
+                      '&::-webkit-scrollbar': {
+                        width: 4,
                       },
+                      '&::-webkit-scrollbar-track': {
+                        boxShadow: `inset 10px 10px  #E6E9F2`,
+                        marginY: '3px',
+                      },
+                      '&::-webkit-scrollbar-thumb': {
+                        backgroundColor: '#0073E6',
+                        borderRadius: '16px',
+                      },
+                      overflowY: 'auto',
+                      maxHeight: '200px',
+                      boxShadow:
+                        '0px 6px 30px 5px rgba(0, 43, 85, 0.10), 0px 16px 24px 2px rgba(0, 43, 85, 0.05), 0px 8px 10px -5px rgba(0, 43, 85, 0.10)',
                     },
-                  }}
-                  renderOption={(props, option: InstitutionLocationData) => (
-                    <MenuItem key={option.code} {...props} sx={{ height: '44px' }}>
-                      {option?.city}
-                    </MenuItem>
-                  )}
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      sx={{
-                        '& .MuiOutlinedInput-input.MuiInputBase-input.MuiInputBase-inputAdornedEnd.MuiAutocomplete-input.MuiAutocomplete-inputFocused':
-                          {
-                            marginLeft: '16px',
-                            fontWeight: 'fontWeightRegular',
-                            textTransform: 'capitalize',
-                            color: theme.palette.text.secondary,
-                          },
-                      }}
-                      label={t('onboardingFormData.billingDataSection.city')}
-                    />
-                  )}
-                />
-              </Grid>
-              <Grid item xs={5}>
-                <CustomTextField
-                  {...baseTextFieldProps(
-                    'county',
-                    t('onboardingFormData.billingDataSection.county'),
-                    400,
-                    18
-                  )}
-                  InputLabelProps={{ shrink: shrinkCounty }}
-                  disabled={true}
-                />
-              </Grid>
+                  },
+                }}
+                renderOption={(props, option: InstitutionLocationData) => (
+                  <MenuItem key={option.code} {...props} sx={{ height: '44px' }}>
+                    {option?.city}
+                  </MenuItem>
+                )}
+                renderInput={(params: any) => (
+                  <TextField
+                    {...params}
+                    inputProps={{
+                      ...params.inputProps,
+                      value: isFromIPA ? formik.values.city : params.inputProps.value,
+                    }}
+                    label={t('onboardingFormData.billingDataSection.city')}
+                    InputLabelProps={{
+                      shrink: formik.values.city && formik.values.city !== '',
+                    }}
+                    sx={{
+                      '& .MuiOutlinedInput-input.MuiInputBase-input.MuiInputBase-inputAdornedEnd.MuiAutocomplete-input.MuiAutocomplete-inputFocused':
+                        {
+                          marginLeft: '16px',
+                          fontWeight: 'fontWeightRegular',
+                          textTransform: 'capitalize',
+                          color: theme.palette.text.secondary,
+                        },
+                    }}
+                    disabled={isFromIPA}
+                  />
+                )}
+              />
             </Grid>
-          )}
+            <Grid item xs={5}>
+              <CustomTextField
+                {...baseTextFieldProps(
+                  'county',
+                  t('onboardingFormData.billingDataSection.county'),
+                  400,
+                  18
+                )}
+                InputLabelProps={{ shrink: shrinkCounty }}
+                disabled={true}
+              />
+            </Grid>
+          </Grid>
+
           {/* Indirizzo PEC */}
           <Grid item xs={12}>
             <CustomTextField

--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -82,6 +82,7 @@ export default function StepOnboardingFormData({
   subProductId,
   aooSelected,
   uoSelected,
+  selectedParty,
 }: Props) {
   const { t } = useTranslation();
   const { setRequiredLogin } = useContext(UserContext);
@@ -510,6 +511,7 @@ export default function StepOnboardingFormData({
           aooSelected={aooSelected}
           uoSelected={uoSelected}
           institutionAvoidGeotax={institutionAvoidGeotax}
+          selectedParty={selectedParty}
         />
         {/* DATI RELATIVI ALLA TASSONOMIA */}
         {ENV.GEOTAXONOMY.SHOW_GEOTAXONOMY && !institutionAvoidGeotax ? (

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -28,7 +28,8 @@ const createPartyRegistryEntity = (
   originId: string,
   origin: string,
   category: string,
-  address: string
+  address: string,
+  istat_code: string
 ) => ({
   id,
   o,
@@ -45,6 +46,7 @@ const createPartyRegistryEntity = (
   origin,
   category,
   address,
+  istat_code,
 });
 
 const createPartyEntity = (
@@ -57,8 +59,10 @@ const createPartyEntity = (
   digitalAddress: string,
   taxCode: string,
   zipCode: string,
+  istat_code: string,
   userRole: UserRole = 'ADMIN',
-  origin: string = 'IPA'
+  origin: string = 'IPA',
+  
 ) => ({
   externalId,
   originId,
@@ -71,6 +75,7 @@ const createPartyEntity = (
   zipCode,
   userRole,
   origin,
+  istat_code,
 });
 
 const mockPartyRegistry = {
@@ -90,7 +95,8 @@ const mockPartyRegistry = {
       '991',
       'IPA',
       'g1122',
-      'largo torino'
+      'largo torino',
+      'istat1'
     ),
     createPartyRegistryEntity(
       'error',
@@ -107,7 +113,8 @@ const mockPartyRegistry = {
       '352',
       'IPA',
       'c723',
-      'via lombardia'
+      'via lombardia',
+      'istat2'
     ),
     createPartyRegistryEntity(
       'onboarded',
@@ -124,7 +131,8 @@ const mockPartyRegistry = {
       '442',
       'IPA',
       'c11',
-      'piazza rossi'
+      'piazza rossi',
+      'istat3'
     ),
     createPartyRegistryEntity(
       'pending',
@@ -141,7 +149,8 @@ const mockPartyRegistry = {
       '221',
       'IPA',
       'c2234',
-      'legal_se'
+      'legal_se',
+      'istat4'
     ),
     createPartyRegistryEntity(
       'infoError',
@@ -158,7 +167,8 @@ const mockPartyRegistry = {
       '235',
       'IPA',
       'c14',
-      'sede'
+      'sede',
+      'istat5'
     ),
     createPartyRegistryEntity(
       'notAllowed',
@@ -175,7 +185,8 @@ const mockPartyRegistry = {
       'originId6',
       'IPA',
       'c17',
-      'leg'
+      'leg',
+      'istat6'
     ),
     createPartyRegistryEntity(
       'notAllowedInSubmit',
@@ -192,7 +203,8 @@ const mockPartyRegistry = {
       'originId7',
       'IPA',
       'c18',
-      'ss'
+      'ss',
+      'istat7'
     ),
     // use case added for easily test new feature about taxCode equal to vatCode
     createPartyRegistryEntity(
@@ -210,7 +222,8 @@ const mockPartyRegistry = {
       'originId1',
       'IPAIPA', // Origin not equal to IPA, enabled field
       'c17',
-      'mockaddress'
+      'mockaddress',
+      'istat8'
     ),
   ],
   count: 8,
@@ -226,7 +239,8 @@ const mockedParties = [
     'address1',
     'a@aa.com',
     '33344455567',
-    '22345'
+    '22345',
+    'istat1'
   ),
   createPartyEntity(
     'externalId2',
@@ -237,7 +251,8 @@ const mockedParties = [
     'address2',
     'a@cd.com',
     '11122233345',
-    '22395'
+    '22395',
+    'istat2'
   ),
   createPartyEntity(
     'externalId3',
@@ -248,7 +263,8 @@ const mockedParties = [
     'address',
     'a@aa.com',
     '33322268945',
-    '02102'
+    '02102',
+    'istat3'
   ),
   createPartyEntity(
     'externalId4',
@@ -259,7 +275,8 @@ const mockedParties = [
     '33445673210',
     'address4',
     'b@bb.com',
-    '00022'
+    '00022',
+    'istat4'
   ),
   createPartyEntity(
     '33445673211',
@@ -270,7 +287,8 @@ const mockedParties = [
     'address5',
     'b@cc.com',
     '33445673211',
-    '33344'
+    '33344',
+    'istat5'
   ),
   createPartyEntity(
     'onboarded_externalId',
@@ -281,7 +299,8 @@ const mockedParties = [
     'address',
     'a@aa.com',
     'BBBBBB22B22B234K',
-    '12125'
+    '12125',
+    'istat6',
   ),
   createPartyEntity(
     'aooId',
@@ -292,7 +311,8 @@ const mockedParties = [
     'address',
     'a@aa.com',
     'BBBBBB22B22B234K',
-    '12125'
+    '12125',
+    'istat7',
   ),
 ];
 
@@ -343,6 +363,18 @@ export const mockedGeoTaxonomy: Array<GeographicTaxonomyResource> = [
     region_id: '65',
   },
 ];
+
+export const mockedGeoTaxByIstatCode: GeographicTaxonomyResource = {
+  country: '100',
+  enabled: true,
+  code: '082053',
+  desc: 'PALERMO - COMUNE',
+  istat_code: '082053',
+  province_id: '082',
+  province_abbreviation: 'PA',
+  region_id: '19',
+  country_abbreviation: 'IT',
+};
 
 const mockedAooCode: AooData = {
   codAoo: 'A356E00',
@@ -740,6 +772,12 @@ export async function mockFetch(
   if (endpoint === 'ONBOARDING_GET_PREVIOUS_GEOTAXONOMIES') {
     return new Promise((resolve) =>
       resolve({ data: mockedGeoTaxonomy, status: 200, statusText: '200' } as AxiosResponse)
+    );
+  }
+
+  if (endpoint === 'ONBOARDING_GET_LOCATION_BY_ISTAT_CODE') {
+    return new Promise((resolve) =>
+      resolve({ data: mockedGeoTaxByIstatCode, status: 200, statusText: '200' } as AxiosResponse)
     );
   }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -45,7 +45,7 @@ export const ROUTES: RoutesObject = {
 };
 
 export const API = {
-
+  
   VERIFY_ONBOARDING: {
     URL: ENV.URL_API.ONBOARDING + '/institutions/onboarding',
   },
@@ -91,6 +91,9 @@ export const API = {
   },
   ONBOARDING_GET_PREVIOUS_GEOTAXONOMIES: {
     URL: ENV.URL_API.ONBOARDING + '/institutions/geographicTaxonomies',
+  },
+  ONBOARDING_GET_LOCATION_BY_ISTAT_CODE: {
+    URL: ENV.URL_API.PARTY_REGISTRY_PROXY + '/geotaxonomies/{{geoTaxId}}',
   },
   ONBOARDING_GET_UO_CODE_INFO: {
     URL: ENV.URL_API.PARTY_REGISTRY_PROXY + '/uo/{{codiceUniUo}}',

--- a/src/utils/formatting-utils.ts
+++ b/src/utils/formatting-utils.ts
@@ -1,0 +1,5 @@
+export const formatCity = (city: string): string =>
+  city
+    .charAt(0)
+    .toUpperCase()
+    .concat(city.substring(1).toLowerCase().replace('- comune', '').trim());

--- a/src/views/onboarding/__tests__/Onboarding.test.tsx
+++ b/src/views/onboarding/__tests__/Onboarding.test.tsx
@@ -103,6 +103,30 @@ test('test already onboarded', async () => {
   await executeGoHome(false);
 });
 
+test('onboarding of pa with origin IPA', async () => {
+  renderComponent('prod-pagopa');
+  await executeStepInstitutionType('prod-pagopa');
+  await executeStep1('AGENCY X', 'prod-pagopa', 'pa');
+  const searchCitySelect = document.getElementById('city-select') as HTMLInputElement;
+  const searchCounty = document.getElementById('county');
+
+  await waitFor(() => expect(searchCitySelect.value).toBe('Palermo'));
+  await waitFor(() => expect(searchCounty).toBeDisabled());
+  await fillUserBillingDataForm(
+    'businessName',
+    'registeredOffice',
+    'digitalAddress',
+    'zipCode',
+    'taxCode',
+    'vatNumber',
+    'recipientCode',
+    'supportEmail'
+  );
+
+  const confirmButtonEnabled = screen.getByRole('button', { name: 'Continua' });
+  await waitFor(() => expect(confirmButtonEnabled).toBeEnabled());
+});
+
 test('test error retrieving onboarding info', async () => {
   renderComponent('prod-pagopa');
   await executeStepInstitutionType('prod-pagopa');
@@ -203,10 +227,10 @@ test('test complete onboarding AOO with product interop', async () => {
   await executeAdvancedSearchForAoo();
   await executeStep2();
   await executeStep3(true);
-  const onboardingComlpeted = await waitFor(() =>
+  const onboardingCompleted = await waitFor(() =>
     screen.getByText('Richiesta di adesione inviata')
   );
-  expect(onboardingComlpeted).toBeInTheDocument();
+  expect(onboardingCompleted).toBeInTheDocument();
 });
 
 test('test label recipientCode only for institutionType is not PA', async () => {
@@ -432,7 +456,7 @@ const executeAdvancedSearchForAoo = async () => {
   expect(confirmButton).toBeEnabled();
 
   fireEvent.click(confirmButton);
-  await waitFor(() => expect(fetchWithLogsSpy).toBeCalledTimes(6));
+  await waitFor(() => expect(fetchWithLogsSpy).toBeCalledTimes(7));
 
   const aooCode = document.getElementById('aooUniqueCode') as HTMLInputElement;
   const aooName = document.getElementById('aooName') as HTMLInputElement;

--- a/types.ts
+++ b/types.ts
@@ -190,6 +190,7 @@ export type Party = {
   origin: string;
   // indirizzo mail supporto
   supportEmail?: string;
+  istat_code?: string;
 };
 
 export type InstitutionData = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
* SELC-3362 city and county fields visible for institutions from IPA.
Integrated new api that takes istat code as param and return location data  
<!--- Describe your changes in detail -->

#### Motivation and Context
During onboarding for institutions with origin IPA the fields city should be prefilled and be read only.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.