### PR TITLE
Fix: hide cities options from autocomplete dropdown

### DIFF
--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -72,6 +72,7 @@ export default function PersonalAndBillingDataSection({
   const [shrinkCounty, setShrinkCounty] = useState<boolean>(false);
   const [countries, setCountries] = useState<Array<InstitutionLocationData>>();
   const [institutionLocationData, setInstitutionLocationData] = useState<InstitutionLocationData>();
+  const [isCitySelected, setIsCitySelected] = useState<boolean>(false);
 
   useEffect(() => {
     const shareCapitalIsNan = isNaN(formik.values.shareCapital);
@@ -329,14 +330,24 @@ export default function PersonalAndBillingDataSection({
                   const value = e.target.value as string;
                   if (value.length >= 3) {
                     void getCountriesFromGeotaxonomies(value);
+                  } else {
+                    setCountries(undefined);
                   }
                 }}
                 onChange={(_e: any, selected: any) => {
                   if (selected) {
                     setShrinkCounty(true);
                     setInstitutionLocationData(selected);
+                    setIsCitySelected(true);
                   } else {
                     setShrinkCounty(false);
+                    setCountries(undefined);
+                    setInstitutionLocationData(undefined);
+                    setIsCitySelected(false);
+                  }
+                }}
+                onBlur={() => {
+                  if (!isCitySelected) {
                     setCountries(undefined);
                     setInstitutionLocationData(undefined);
                   }
@@ -344,7 +355,8 @@ export default function PersonalAndBillingDataSection({
                 getOptionLabel={(o) => o.city}
                 options={countries ?? []}
                 noOptionsText={t('onboardingFormData.billingDataSection.noResult')}
-                popupIcon={isFromIPA ? '' : undefined}
+                clearOnBlur={true}
+                forcePopupIcon={isFromIPA ? false : true}
                 disabled={isFromIPA}
                 ListboxProps={{
                   style: {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
 Hide cities options from autocomplete dropdown when no value is selected
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.