### PR TITLE
[SELC-3402] fix city and county fields for UO/AOO

### DIFF
--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -112,10 +112,16 @@ export default function PersonalAndBillingDataSection({
   const isAooUo = aooSelected || uoSelected;
 
   useEffect(() => {
-    if (isFromIPA && selectedParty?.istatCode) {
-      void getLocationFromIstatCode(selectedParty.istatCode);
+    if (isFromIPA) {
+      if (aooSelected) {
+        void getLocationFromIstatCode(aooSelected.codiceComuneISTAT);
+      } else if (uoSelected) {
+        void getLocationFromIstatCode(uoSelected.codiceComuneISTAT);
+      } else if  (selectedParty?.istatCode){
+        void getLocationFromIstatCode(selectedParty.istatCode);
+      }
     }
-  }, [institutionType, selectedParty]);
+  }, [isFromIPA, selectedParty,aooSelected, uoSelected]);
 
   const baseNumericFieldProps = (
     field: keyof OnboardingFormData,

--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -1,22 +1,22 @@
-import { Box, styled } from '@mui/system';
-import { useContext, useEffect, useState } from 'react';
-import { Grid, TextField, Typography, Paper, MenuItem } from '@mui/material';
-import { useTranslation } from 'react-i18next';
-import Checkbox from '@mui/material/Checkbox';
-import { theme } from '@pagopa/mui-italia';
+import { Grid, MenuItem, Paper, TextField, Typography } from '@mui/material';
 import Autocomplete from '@mui/material/Autocomplete';
+import Checkbox from '@mui/material/Checkbox';
+import { Box, styled } from '@mui/system';
+import { theme } from '@pagopa/mui-italia';
 import { AxiosResponse } from 'axios';
+import { useContext, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { InstitutionType, Party, StepperStepComponentProps } from '../../../types';
-import { OnboardingFormData } from '../../model/OnboardingFormData';
-import { StepBillingDataHistoryState } from '../steps/StepOnboardingFormData';
-import { AooData } from '../../model/AooData';
-import { UoData } from '../../model/UoModel';
 import { fetchWithLogs } from '../../lib/api-utils';
-import { getFetchOutcome } from '../../lib/error-utils';
-import { GeographicTaxonomyResource } from '../../model/GeographicTaxonomies';
 import { UserContext } from '../../lib/context';
+import { getFetchOutcome } from '../../lib/error-utils';
+import { AooData } from '../../model/AooData';
+import { GeographicTaxonomyResource } from '../../model/GeographicTaxonomies';
 import { InstitutionLocationData } from '../../model/InstitutionLocationData';
+import { OnboardingFormData } from '../../model/OnboardingFormData';
+import { UoData } from '../../model/UoModel';
 import { formatCity } from '../../utils/formatting-utils';
+import { StepBillingDataHistoryState } from '../steps/StepOnboardingFormData';
 import NumberDecimalFormat from './NumberDecimalFormat';
 
 const CustomTextField = styled(TextField)({
@@ -113,15 +113,15 @@ export default function PersonalAndBillingDataSection({
 
   useEffect(() => {
     if (isFromIPA) {
-      if (aooSelected) {
+      if (aooSelected?.codiceComuneISTAT) {
         void getLocationFromIstatCode(aooSelected.codiceComuneISTAT);
-      } else if (uoSelected) {
+      } else if (uoSelected?.codiceComuneISTAT) {
         void getLocationFromIstatCode(uoSelected.codiceComuneISTAT);
-      } else if  (selectedParty?.istatCode){
+      } else if (selectedParty?.istatCode) {
         void getLocationFromIstatCode(selectedParty.istatCode);
       }
     }
-  }, [isFromIPA, selectedParty,aooSelected, uoSelected]);
+  }, [isFromIPA, selectedParty, aooSelected, uoSelected]);
 
   const baseNumericFieldProps = (
     field: keyof OnboardingFormData,

--- a/src/views/onboarding/__tests__/Onboarding.test.tsx
+++ b/src/views/onboarding/__tests__/Onboarding.test.tsx
@@ -464,6 +464,9 @@ const executeAdvancedSearchForAoo = async () => {
   await waitFor(() => expect(aooCode.value).toBe('A356E00'));
   await waitFor(() => expect(aooName.value).toBe('Denominazione Aoo Test'));
 
+  const searchCitySelect = document.getElementById('city-select') as HTMLInputElement;
+  expect(searchCitySelect.value).toBe('Palermo');
+
   const isTaxCodeEquals2PIVA = document.getElementById('onboardingFormData');
   expect(isTaxCodeEquals2PIVA).toBeTruthy();
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Read the fields city and county from the AOO / UO not from the central institution.
Call proxy registry with istat code of aoo / uo.
<!--- Describe your changes in detail -->

#### Motivation and Context
During onboarding with aoo or uo the city and county fields would be filled with the value of the central institution 
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Integration testing from local and unit test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.