### PR TITLE
[SELC-3393] feat: Retrieved Istatcode in premium flow in order to be able to obtain city, country, county

### DIFF
--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -48,6 +48,7 @@ type Props = StepperStepComponentProps & {
   uoSelected?: UoData;
   institutionAvoidGeotax: boolean;
   selectedParty?: Party;
+  retrievedIstat?: string;
 };
 
 // eslint-disable-next-line sonarjs/cognitive-complexity, complexity
@@ -64,6 +65,7 @@ export default function PersonalAndBillingDataSection({
   uoSelected,
   institutionAvoidGeotax,
   selectedParty,
+  retrievedIstat,
 }: Props) {
   const { t } = useTranslation();
   const { setRequiredLogin } = useContext(UserContext);
@@ -109,19 +111,21 @@ export default function PersonalAndBillingDataSection({
   const isDisabled = premiumFlow || (isFromIPA && !isPA && !isPSP) || isPA;
   const recipientCodeVisible = !isContractingAuthority && !isTechPartner && !isInsuranceCompany;
   const requiredError = 'Required';
-  const isAooUo = aooSelected || uoSelected;
+  const isAooUo = !!(aooSelected || uoSelected);
 
   useEffect(() => {
-    if (isFromIPA) {
+    if (isFromIPA || isAooUo) {
       if (aooSelected?.codiceComuneISTAT) {
         void getLocationFromIstatCode(aooSelected.codiceComuneISTAT);
       } else if (uoSelected?.codiceComuneISTAT) {
         void getLocationFromIstatCode(uoSelected.codiceComuneISTAT);
       } else if (selectedParty?.istatCode) {
         void getLocationFromIstatCode(selectedParty.istatCode);
+      } else if (retrievedIstat) {
+        void getLocationFromIstatCode(retrievedIstat);
       }
     }
-  }, [isFromIPA, selectedParty, aooSelected, uoSelected]);
+  }, [isFromIPA, selectedParty, aooSelected, uoSelected, retrievedIstat]);
 
   const baseNumericFieldProps = (
     field: keyof OnboardingFormData,
@@ -350,7 +354,7 @@ export default function PersonalAndBillingDataSection({
                 noOptionsText={t('onboardingFormData.billingDataSection.noResult')}
                 clearOnBlur={true}
                 forcePopupIcon={isFromIPA ? false : true}
-                disabled={isFromIPA}
+                disabled={isFromIPA || isAooUo}
                 ListboxProps={{
                   style: {
                     overflow: 'visible',
@@ -387,7 +391,7 @@ export default function PersonalAndBillingDataSection({
                     {...params}
                     inputProps={{
                       ...params.inputProps,
-                      value: isFromIPA ? formik.values.city : params.inputProps.value,
+                      value: isFromIPA || isAooUo ? formik.values.city : params.inputProps.value,
                     }}
                     label={t('onboardingFormData.billingDataSection.city')}
                     InputLabelProps={{
@@ -403,7 +407,7 @@ export default function PersonalAndBillingDataSection({
                           : theme.palette.text.primary,
                       },
                     }}
-                    disabled={isFromIPA}
+                    disabled={isFromIPA || isAooUo}
                   />
                 )}
               />

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -61,8 +61,7 @@ const createPartyEntity = (
   zipCode: string,
   istatCode: string,
   userRole: UserRole = 'ADMIN',
-  origin: string = 'IPA',
-  
+  origin: string = 'IPA'
 ) => ({
   externalId,
   originId,
@@ -96,7 +95,7 @@ const mockPartyRegistry = {
       'IPA',
       'g1122',
       'largo torino',
-      'istat1'
+      '082050'
     ),
     createPartyRegistryEntity(
       'error',
@@ -238,9 +237,9 @@ const mockedParties = [
     'logo1',
     'address1',
     'a@aa.com',
-    '33344455567',
+    '33445673222',
     '22345',
-    'istat1'
+    '082050'
   ),
   createPartyEntity(
     'externalId2',
@@ -288,7 +287,9 @@ const mockedParties = [
     'b@cc.com',
     '33445673211',
     '33344',
-    'istat5'
+    '082051',
+    'ADMIN',
+    'INFOCAMERE'
   ),
   createPartyEntity(
     'onboarded_externalId',
@@ -300,7 +301,7 @@ const mockedParties = [
     'a@aa.com',
     'BBBBBB22B22B234K',
     '12125',
-    'istat6',
+    'istat6'
   ),
   createPartyEntity(
     'aooId',
@@ -312,7 +313,7 @@ const mockedParties = [
     'a@aa.com',
     'BBBBBB22B22B234K',
     '12125',
-    'istat7',
+    'istat7'
   ),
 ];
 
@@ -364,17 +365,30 @@ export const mockedGeoTaxonomy: Array<GeographicTaxonomyResource> = [
   },
 ];
 
-export const mockedGeoTaxByIstatCode: GeographicTaxonomyResource = {
-  country: '100',
-  enabled: true,
-  code: '082053',
-  desc: 'PALERMO - COMUNE',
-  istat_code: '082053',
-  province_id: '082',
-  province_abbreviation: 'PA',
-  region_id: '19',
-  country_abbreviation: 'IT',
-};
+export const mockedGeotaxonomies: Array<GeographicTaxonomyResource> = [
+  {
+    country: '100',
+    enabled: true,
+    code: '082053',
+    desc: 'PALERMO - COMUNE',
+    istat_code: '082050',
+    province_id: '082',
+    province_abbreviation: 'PA',
+    region_id: '19',
+    country_abbreviation: 'IT',
+  },
+  {
+    country: '100',
+    enabled: true,
+    code: '082053',
+    desc: 'ROMA - COMUNE',
+    istat_code: '082051',
+    province_id: '082',
+    province_abbreviation: 'PA',
+    region_id: '19',
+    country_abbreviation: 'IT',
+  },
+];
 
 const mockedAooCode: AooData = {
   codAoo: 'A356E00',
@@ -388,7 +402,7 @@ const mockedAooCode: AooData = {
   origin: 'IPA',
   CAP: '53100',
   codiceCatastaleComune: 'I726',
-  codiceComuneISTAT: '052032',
+  codiceComuneISTAT: '082050',
   cognomeResponsabile: 'Bielli',
   nomeResponsabile: 'Silvia',
   dataIstituzione: '2023-01-27',
@@ -461,7 +475,8 @@ const mockedOnboardingData: Array<InstitutionOnboardingInfoResource> = [
         ],
         supportEmail: 'comune.udine@pec.it',
       },
-      institutionType: 'PA',
+      // Use case not retrieved institution local data
+      institutionType: 'GSP',
       origin: 'IPA',
       assistanceContacts: {
         supportEmail: 'supportemail@mockmail.it',
@@ -776,14 +791,19 @@ export async function mockFetch(
   }
 
   if (endpoint === 'ONBOARDING_GET_LOCATION_BY_ISTAT_CODE') {
+    const retrievedLocalization = mockedGeotaxonomies.find(
+      (l) => endpointParams.geoTaxId === l.istat_code
+    );
     return new Promise((resolve) =>
-      resolve({ data: mockedGeoTaxByIstatCode, status: 200, statusText: '200' } as AxiosResponse)
+      resolve({ data: retrievedLocalization, status: 200, statusText: '200' } as AxiosResponse)
     );
   }
 
   if (endpoint === 'ONBOARDING_GET_PARTY_FROM_CF') {
+    const matchedParty = mockedParties.find((p) => p.taxCode === endpointParams.id);
+
     return new Promise((resolve) =>
-      resolve({ data: mockedParties[0], status: 200, statusText: '200' } as AxiosResponse)
+      resolve({ data: matchedParty, status: 200, statusText: '200' } as AxiosResponse)
     );
   }
 

--- a/src/views/OnBoardingSubProduct/components/SubProductSubmitFetch.ts
+++ b/src/views/OnBoardingSubProduct/components/SubProductSubmitFetch.ts
@@ -70,6 +70,11 @@ export const subProductSubmitFetch = async ({
           institutionType !== 'PSP' && institutionType !== 'PA'
             ? companyInformationsDto2pspDataRequest(billingData as OnboardingFormData)
             : undefined,
+        institutionLocationData: {
+          country: billingData?.country,
+          county: billingData?.county,
+          city: billingData?.city,
+        },
         productId: subProduct.id,
         subunitCode: undefined,
         subunitType: undefined,

--- a/src/views/onboarding/__tests__/Onboarding.test.tsx
+++ b/src/views/onboarding/__tests__/Onboarding.test.tsx
@@ -417,7 +417,7 @@ const executeAdvancedSearchForTaxCode = async (partyName: string) => {
   fireEvent.click(option);
 
   expect(inputPartyName).toBeTruthy();
-  await waitFor(() => fireEvent.change(inputPartyName, { target: { value: '33344455567' } }));
+  await waitFor(() => fireEvent.change(inputPartyName, { target: { value: '33445673222' } }));
 
   expect(fetchWithLogsSpy).toBeCalledTimes(2);
 

--- a/types.ts
+++ b/types.ts
@@ -7,6 +7,7 @@ import { API } from './src/utils/constants';
 import { OnboardingFormData } from './src/model/OnboardingFormData';
 import { AssistanceContacts } from './src/model/AssistanceContacts';
 import { CompanyInformations } from './src/model/CompanyInformations';
+import { GeographicTaxonomy } from './src/model/GeographicTaxonomies';
 
 /*
  * Fetch data and router related types
@@ -200,6 +201,7 @@ export type InstitutionData = {
   origin: string;
   companyInformations?: CompanyInformations;
   assistanceContacts?: AssistanceContacts;
+  geographicTaxonomies?: Array<GeographicTaxonomy>;
 };
 
 export type InstitutionOnboardingInfoResource = {


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Retrieved Istatcode in premium flow in order to be able to obtain city, country, county

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In order to be able to obtain city, country, county for the estabilished conditions also in premium onboarding flow and then, pre-fill the city and county fields

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested aiming DEV data, the fields are prefilled for public administrations parties, also adapted mocks and make the logic work also in local environment
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.