### PR TITLE
fix: Enabled continue button when form is prefilled in premium onboarding flow

### DIFF
--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -319,8 +319,8 @@ export default function StepOnboardingFormData({
             : isVatRegistrated
             ? t('onboardingFormData.billingDataSection.vatNumberAlreadyRegistered')
             : undefined,
-        city: !values.city ? requiredError : undefined,
-        county: !values.county ? requiredError : undefined,
+        city: !premiumFlow && !values.city ? requiredError : undefined,
+        county: !premiumFlow && !values.county ? requiredError : undefined,
         ivassCode:
           isInsuranceCompany && !values.ivassCode
             ? requiredError


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Enabled continue button when form is prefilled in premium onboarding flow

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In order to not have a disabled button when form is valid

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Local execution
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.