### PR TITLE
feat: aoo and uo option for party search enabled for send only for PAL categories

### DIFF
--- a/src/components/autocomplete/components/partyAdvancedSearchType/PartyAdvancedSelect.tsx
+++ b/src/components/autocomplete/components/partyAdvancedSearchType/PartyAdvancedSelect.tsx
@@ -93,7 +93,8 @@ export default function PartyAdvancedSelect({
     product &&
     (product.id === 'prod-interop' ||
       product.id === 'prod-io-sign' ||
-      product.id === 'prod-pn-dev');
+      product.id === 'prod-pn-dev' ||
+      product.id === 'prod-pn');
   const optionsAvailable4InstitutionType = institutionType !== 'SA' && institutionType !== 'AS';
 
   const menuItems = [


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
AOO and UO option for party search enabled for send only for PAL categories

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
For allow onboarding from aoo / uo parties also for SEND product for the wanted categories (L6, L4, L45 as central parties)

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in DEV, searching an aooCode and uoCode of ipa categories L37 and the output is correctly not found
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.