### PR TITLE
[SELC-3496] fix: Handle fields city county for premium flow

### DIFF
--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -49,6 +49,7 @@ type Props = StepperStepComponentProps & {
   institutionAvoidGeotax: boolean;
   selectedParty?: Party;
   retrievedIstat?: string;
+  isCityEditable?: boolean;
 };
 
 // eslint-disable-next-line sonarjs/cognitive-complexity, complexity
@@ -66,6 +67,7 @@ export default function PersonalAndBillingDataSection({
   institutionAvoidGeotax,
   selectedParty,
   retrievedIstat,
+  isCityEditable,
 }: Props) {
   const { t } = useTranslation();
   const { setRequiredLogin } = useContext(UserContext);
@@ -102,6 +104,16 @@ export default function PersonalAndBillingDataSection({
     }
   }, [institutionLocationData]);
 
+  useEffect(() => {
+    if (premiumFlow) {
+      setInstitutionLocationData({
+        country: formik.values.country,
+        county: formik.values.county,
+        city: formik.values.city,
+      });
+    }
+  }, [premiumFlow]);
+
   const isFromIPA = origin === 'IPA';
   const isPSP = institutionType === 'PSP';
   const isPA = institutionType === 'PA';
@@ -114,7 +126,7 @@ export default function PersonalAndBillingDataSection({
   const isAooUo = !!(aooSelected || uoSelected);
 
   useEffect(() => {
-    if (isFromIPA || isAooUo) {
+    if (!premiumFlow && (isFromIPA || isAooUo)) {
       if (aooSelected?.codiceComuneISTAT) {
         void getLocationFromIstatCode(aooSelected.codiceComuneISTAT);
       } else if (uoSelected?.codiceComuneISTAT) {
@@ -125,7 +137,7 @@ export default function PersonalAndBillingDataSection({
         void getLocationFromIstatCode(retrievedIstat);
       }
     }
-  }, [isFromIPA, selectedParty, aooSelected, uoSelected, retrievedIstat]);
+  }, [isFromIPA, selectedParty, aooSelected, uoSelected, retrievedIstat, premiumFlow]);
 
   const baseNumericFieldProps = (
     field: keyof OnboardingFormData,
@@ -354,7 +366,7 @@ export default function PersonalAndBillingDataSection({
                 noOptionsText={t('onboardingFormData.billingDataSection.noResult')}
                 clearOnBlur={true}
                 forcePopupIcon={isFromIPA ? false : true}
-                disabled={isFromIPA || isAooUo}
+                disabled={(premiumFlow && !isCityEditable) || isFromIPA || isAooUo}
                 ListboxProps={{
                   style: {
                     overflow: 'visible',
@@ -407,7 +419,7 @@ export default function PersonalAndBillingDataSection({
                           : theme.palette.text.primary,
                       },
                     }}
-                    disabled={isFromIPA || isAooUo}
+                    disabled={(premiumFlow && !isCityEditable) || isFromIPA || isAooUo}
                   />
                 )}
               />

--- a/src/components/steps/StepOnboardingData.tsx
+++ b/src/components/steps/StepOnboardingData.tsx
@@ -95,7 +95,10 @@ function StepOnboardingData({
         result.institution.institutionType ? result.institution.institutionType : institutionType,
         result.institution.id,
         result.institution.assistanceContacts,
-        result.institution.companyInformations
+        result.institution.companyInformations,
+        result.institution.country,
+        result.institution.city,
+        result.institution.county
       );
     } else if (
       (onboardingData as AxiosError<any>).response?.status === 404 ||

--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -68,6 +68,7 @@ type Props = StepperStepComponentProps & {
   outcome?: RequestOutcomeMessage | null;
   aooSelected?: AooData;
   uoSelected?: UoData;
+  isCityEditable?: boolean;
 };
 
 export default function StepOnboardingFormData({
@@ -84,6 +85,7 @@ export default function StepOnboardingFormData({
   aooSelected,
   uoSelected,
   selectedParty,
+  isCityEditable,
 }: Props) {
   const { t } = useTranslation();
   const { setRequiredLogin } = useContext(UserContext);
@@ -546,6 +548,7 @@ export default function StepOnboardingFormData({
           institutionAvoidGeotax={institutionAvoidGeotax}
           selectedParty={selectedParty}
           retrievedIstat={retrievedIstat}
+          isCityEditable={isCityEditable}
         />
         {/* DATI RELATIVI ALLA TASSONOMIA */}
         {ENV.GEOTAXONOMY.SHOW_GEOTAXONOMY && !institutionAvoidGeotax ? (

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -294,7 +294,7 @@ const mockedParties = [
   createPartyEntity(
     'onboarded_externalId',
     'or2325',
-    'p4341',
+    'p23412',
     'onboarded',
     'logo',
     'address',
@@ -452,8 +452,11 @@ const mockedOnboardingData: Array<InstitutionOnboardingInfoResource> = [
         ],
         supportEmail: 'comune.bollate@pec.it',
       },
+      city: 'Milano',
+      country: 'IT',
+      county: 'MI',
       institutionType: 'PA',
-      origin: 'IPA',
+      origin: 'ANAC',
     },
   },
   {
@@ -475,6 +478,9 @@ const mockedOnboardingData: Array<InstitutionOnboardingInfoResource> = [
         ],
         supportEmail: 'comune.udine@pec.it',
       },
+      city: 'Udine',
+      country: 'IT',
+      county: 'UD',
       // Use case not retrieved institution local data
       institutionType: 'GSP',
       origin: 'IPA',
@@ -507,6 +513,9 @@ const mockedOnboardingData: Array<InstitutionOnboardingInfoResource> = [
         ],
         supportEmail: 'comune.bollate@pec.it',
       },
+      city: 'Bollate',
+      country: 'IT',
+      county: 'BO',
       institutionType: 'PA',
       origin: 'IPA',
       assistanceContacts: {
@@ -539,6 +548,9 @@ const mockedOnboardingData: Array<InstitutionOnboardingInfoResource> = [
         supportEmail: 'comune.bollate@pec.it',
       },
       institutionType: 'PA',
+      city: 'Bollate',
+      country: 'IT',
+      county: 'BO',
       origin: 'IPA',
       assistanceContacts: {
         supportEmail: 'a@a.it',

--- a/src/model/InstitutionLocationData.ts
+++ b/src/model/InstitutionLocationData.ts
@@ -1,5 +1,5 @@
 export type InstitutionLocationData = {
-  code: string;
+  code?: string;
   county: string;
   country: string;
   city: string;

--- a/src/views/OnBoardingSubProduct/OnBoardingSubProduct.tsx
+++ b/src/views/OnBoardingSubProduct/OnBoardingSubProduct.tsx
@@ -76,6 +76,10 @@ function OnBoardingSubProduct() {
   const [companyInformations, setCompanyInformations] = useState<CompanyInformations>();
   const [openConfirmationModal, setOpenConfirmationModal] = useState(false);
   const [partyName, setPartyName] = useState('');
+  const [country, setCountry] = useState('');
+  const [city, setCity] = useState('');
+  const [county, setCounty] = useState('');
+  const [isCityEditable, setIsCityEditable] = useState(false);
 
   useEffect(() => {
     registerUnloadEvent(setOnExit, setOpenExitModal, setOnExitAction);
@@ -172,7 +176,10 @@ function OnBoardingSubProduct() {
     institutionType?: InstitutionType,
     partyId?: string,
     assistanceContacts?: AssistanceContacts,
-    companyInformations?: CompanyInformations
+    companyInformations?: CompanyInformations,
+    country?: string,
+    city?: string,
+    county?: string
   ) => {
     setStepAddManagerHistoryState({});
 
@@ -184,6 +191,19 @@ function OnBoardingSubProduct() {
     }
     if (companyInformations) {
       setCompanyInformations(companyInformations);
+    }
+
+    if (country) {
+      setCountry(country);
+    }
+    if (city) {
+      setCity(city);
+    }
+    if (!city) {
+      setIsCityEditable(true);
+    }
+    if (county) {
+      setCounty(county);
     }
     setInstitutionType(institutionType);
     setPartyId(partyId);
@@ -289,6 +309,7 @@ function OnBoardingSubProduct() {
           subProductId: subProduct?.id,
           selectedProduct: subProduct,
           externalInstitutionId,
+          isCityEditable,
           initialFormData: {
             ...(billingData ?? {
               businessName: '',
@@ -302,6 +323,9 @@ function OnBoardingSubProduct() {
             }),
             ...assistanceContacts,
             ...companyInformations,
+            city: city ?? '',
+            county: county ?? '',
+            country: country ?? '',
           },
           institutionType: institutionType as InstitutionType,
           origin,

--- a/types.ts
+++ b/types.ts
@@ -202,6 +202,9 @@ export type InstitutionData = {
   companyInformations?: CompanyInformations;
   assistanceContacts?: AssistanceContacts;
   geographicTaxonomies?: Array<GeographicTaxonomy>;
+  country?: string;
+  county?: string;
+  city?: string;
 };
 
 export type InstitutionOnboardingInfoResource = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
In the premium flow, to retrieve the institution data and prepopulate the fields, the onboarded-institution-info API call is available to read the data from.
Removed call to geoTax by istatCode.
<!--- Describe your changes in detail -->

#### Motivation and Context
For public administrations, the fields city, county, country are have been added in onboarded-institution-info API call.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.