### PR TITLE
[SELC-3585] feat: Added mixpanel event for open operative manual

### DIFF
--- a/src/components/BodyLogger.tsx
+++ b/src/components/BodyLogger.tsx
@@ -2,6 +2,7 @@ import { useContext, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Box } from '@mui/system';
 import { Footer, Header } from '@pagopa/selfcare-common-frontend';
+import { trackEvent } from '@pagopa/selfcare-common-frontend/services/analyticsService';
 import { logAction } from '../lib/action-log';
 import { ENV } from '../utils/env';
 import { Main } from './Main';
@@ -45,7 +46,12 @@ export function BodyLogger() {
           onExit={onExit}
           enableAssistanceButton={ENV.ENV !== 'UAT'}
           assistanceEmail={ENV.ASSISTANCE.ENABLE ? ENV.ASSISTANCE.EMAIL : undefined}
-          onDocumentationClick={() => window.open(ENV.URL_DOCUMENTATION, '_blank')}
+          onDocumentationClick={() => {
+            trackEvent('OPEN_OPERATIVE_MANUAL', {
+              from: 'onboarding',
+            });
+            window.open(ENV.URL_DOCUMENTATION, '_blank');
+          }}
           enableLogin={enableLogin}
           loggedUser={
             user


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Added mixpanel event for open operative manual

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In order to make analytics with opening operative manual, the event contains the from property which will be valorised with the point of the application from which the manual is accessed (onboarding/login/dashboard)

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Local
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.