### PR TITLE
[SELC-3501] feat: Hide Recipient code field for prod-interop

### DIFF
--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -50,6 +50,7 @@ type Props = StepperStepComponentProps & {
   selectedParty?: Party;
   retrievedIstat?: string;
   isCityEditable?: boolean;
+  isProdInterop: boolean;
 };
 
 // eslint-disable-next-line sonarjs/cognitive-complexity, complexity
@@ -68,6 +69,7 @@ export default function PersonalAndBillingDataSection({
   selectedParty,
   retrievedIstat,
   isCityEditable,
+  isProdInterop,
 }: Props) {
   const { t } = useTranslation();
   const { setRequiredLogin } = useContext(UserContext);
@@ -121,7 +123,8 @@ export default function PersonalAndBillingDataSection({
   const isInsuranceCompany = institutionType === 'AS';
   const isTechPartner = institutionType === 'PT';
   const isDisabled = premiumFlow || (isFromIPA && !isPA && !isPSP) || isPA;
-  const recipientCodeVisible = !isContractingAuthority && !isTechPartner && !isInsuranceCompany;
+  const recipientCodeVisible =
+    !isContractingAuthority && !isTechPartner && !isInsuranceCompany && !isProdInterop;
   const requiredError = 'Required';
   const isAooUo = !!(aooSelected || uoSelected);
 

--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -121,6 +121,7 @@ export default function StepOnboardingFormData({
     (productId === 'prod-io' || productId === 'prod-io-sign');
   const isProdIoSign = productId === 'prod-io-sign';
   const isProdFideiussioni = productId?.startsWith('prod-fd') ?? false;
+  const isProdInterop = productId === 'prod-interop';
   const aooCode = aooSelected?.codiceUniAoo;
   const uoCode = uoSelected?.codiceUniUo;
 
@@ -371,7 +372,11 @@ export default function StepOnboardingFormData({
             ? t('onboardingFormData.billingDataSection.invalidEmail')
             : undefined,
         recipientCode:
-          !isContractingAuthority && !isTechPartner && !isInsuranceCompany && !values.recipientCode
+          !isContractingAuthority &&
+          !isTechPartner &&
+          !isInsuranceCompany &&
+          !values.recipientCode &&
+          !isProdInterop
             ? requiredError
             : undefined,
         geographicTaxonomies:
@@ -548,6 +553,7 @@ export default function StepOnboardingFormData({
           selectedParty={selectedParty}
           retrievedIstat={retrievedIstat}
           isCityEditable={isCityEditable}
+          isProdInterop={isProdInterop}
         />
         {/* DATI RELATIVI ALLA TASSONOMIA */}
         {ENV.GEOTAXONOMY.SHOW_GEOTAXONOMY && !institutionAvoidGeotax ? (

--- a/src/model/BillingData.ts
+++ b/src/model/BillingData.ts
@@ -6,7 +6,7 @@ export type BillingDataDto = {
     // Indirizzo PEC
     digitalAddress: string;
     // Codice destinatario
-    recipientCode: string;
+    recipientCode?: string;
     // Sede legale
     registeredOffice: string;
     // Codice fiscale

--- a/src/model/OnboardingFormData.ts
+++ b/src/model/OnboardingFormData.ts
@@ -11,7 +11,7 @@ export type OnboardingFormData = {
   country?: string;
   city?: string;
   ivassCode?: string;
-  recipientCode: string;
+  recipientCode?: string;
   publicServices?: boolean;
   commercialRegisterNumber?: string;
   registrationInRegister?: string;

--- a/src/views/onboarding/Onboarding.tsx
+++ b/src/views/onboarding/Onboarding.tsx
@@ -266,7 +266,7 @@ function OnboardingComponent({ productId }: { productId: string }) {
           ? aooResult.codiceUniAoo
           : uoResult && uoResult.codiceUniUo
           ? uoResult.codiceUniUo
-          : '',
+          : undefined,
       registeredOffice: aooResult
         ? aooResult.indirizzo
         : uoResult


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

RecipientCode is not required during onboarding on prod-interop for all institution types.

#### Motivation and Context

Prod-interop does not need recipient code beacuse its not an invoicable product.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.