### PR TITLE
[SELC-3747] feat: handle 404 error in for prod-fd verifyVatNumber API

### DIFF
--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -492,6 +492,7 @@ export default {
       invalidMailSupport: 'L’indirizzo email non è valido',
       invalidShareCapitalField: 'Il campo capitale sociale non è valido',
       vatNumberAlreadyRegistered: 'La P. IVA che hai inserito è già stata registrata.',
+      vatNumberVerificationError: 'Si è verificato un errore durante la verifica della P. IVA.',
       centralPartyLabel: 'Ente centrale',
       businessName: 'Ragione sociale',
       aooName: 'Denominazione AOO',


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Block onboarding flow on prod-fd in case of generic error from verify vat number.
<!--- Describe your changes in detail -->

#### Motivation and Context
During onboarding on prod-fd if the API that verifies that the institution with a specific vat number was already registered returned an error code diffrent from 404 it would still allow to continue with the onboarding flow.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested by aiming at dev env.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.