### PR TITLE
[SELC-3794] feat: Sending the new additionalInformations object in the submit payload

### DIFF
--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -532,7 +532,7 @@ export default function StepOnboardingFormData({
       <Grid container item xs={8} display="flex" justifyContent="center">
         <Grid item xs={12}>
           <Typography variant="h3" component="h2" align="center" sx={{ lineHeight: '1.2' }}>
-            {institutionType === 'PSP' && productId === 'prod-pagopa'
+            {institutionType === 'PSP' || productId === 'prod-pagopa'
               ? t('onboardingFormData.pspAndProdPagoPATitle')
               : institutionType === 'PT'
               ? t('onboardingFormData.billingDataPt.title')

--- a/src/model/AdditionalInformations.ts
+++ b/src/model/AdditionalInformations.ts
@@ -1,0 +1,17 @@
+export type AdditionalInformations = {
+  agentOfPublicService: boolean;
+  agentOfPublicServiceNote: string;
+  belongRegulatedMarket: boolean;
+  regulatedMarketNote: string;
+  establishedByRegulatoryProvision: boolean;
+  establishedByRegulatoryProvisionNote: string;
+  ipa: boolean;
+  ipaCode: string;
+  otherNote: string;
+};
+
+export type AdditionalData = {
+  openTextField: string;
+  textFieldValue: string;
+  choice: boolean;
+};

--- a/src/views/onboarding/Onboarding.tsx
+++ b/src/views/onboarding/Onboarding.tsx
@@ -44,9 +44,10 @@ import StepOnboardingFormData from '../../components/steps/StepOnboardingFormDat
 import { registerUnloadEvent, unregisterUnloadEvent } from '../../utils/unloadEvent-utils';
 import StepInstitutionType from '../../components/steps/StepInstitutionType';
 import UserNotAllowedPage from '../UserNotAllowedPage';
+import { AdditionalData, AdditionalInformations } from '../../model/AdditionalInformations';
 import { genericError, OnboardingStep1_5 } from './components/OnboardingStep1_5';
 import { OnBoardingProductStepDelegates } from './components/OnBoardingProductStepDelegates';
-import { StepAdditionalInfos } from './components/StepAdditionalInfos';
+import { StepAdditionalInformations } from './components/StepAdditionalInformations';
 
 export type ValidateErrorType = 'conflictError';
 
@@ -83,6 +84,7 @@ function OnboardingComponent({ productId }: { productId: string }) {
   const [openExitModal, setOpenExitModal] = useState(false);
   const [selectedProduct, setSelectedProduct] = useState<Product | null>();
   const [onboardingFormData, setOnboardingFormData] = useState<OnboardingFormData>();
+  const [additionalInformations, setAdditionalInformations] = useState<AdditionalInformations>();
   const [institutionType, setInstitutionType] = useState<InstitutionType>();
   const [origin, setOrigin] = useState<string>();
   const [pricingPlan, setPricingPlan] = useState<string>();
@@ -356,6 +358,26 @@ function OnboardingComponent({ productId }: { productId: string }) {
     }
   };
 
+  const forwardWithAdditionalGSPInfo = (newAdditionalInformations: {
+    [key: string]: AdditionalData;
+  }) => {
+    setAdditionalInformations({
+      agentOfPublicService: newAdditionalInformations.isConcessionaireOfPublicService?.choice,
+      agentOfPublicServiceNote:
+        newAdditionalInformations.isConcessionaireOfPublicService?.textFieldValue,
+      belongRegulatedMarket: newAdditionalInformations.fromBelongsRegulatedMarket?.choice,
+      regulatedMarketNote: newAdditionalInformations.fromBelongsRegulatedMarket?.textFieldValue,
+      establishedByRegulatoryProvision:
+        newAdditionalInformations.isEstabilishedRegulatoryProvision?.choice,
+      establishedByRegulatoryProvisionNote:
+        newAdditionalInformations.isEstabilishedRegulatoryProvision?.textFieldValue,
+      ipa: newAdditionalInformations.isFromIPA?.choice,
+      ipaCode: newAdditionalInformations.isFromIPA?.textFieldValue,
+      otherNote: newAdditionalInformations.optionalPartyInformations?.textFieldValue ?? '',
+    });
+    forward();
+  };
+
   const outcomeContent: RequestOutcomeOptions = {
     success: {
       title: '',
@@ -450,6 +472,22 @@ function OnboardingComponent({ productId }: { productId: string }) {
         method: 'POST',
         data: {
           billingData: billingData2billingDataRequest(onboardingFormData as OnboardingFormData),
+          additionalInformations:
+            institutionType === 'GSP' && selectedProduct?.id === 'prod-pagopa'
+              ? {
+                  agentOfPublicService: additionalInformations?.agentOfPublicService,
+                  agentOfPublicServiceNote: additionalInformations?.agentOfPublicServiceNote,
+                  belongRegulatedMarket: additionalInformations?.belongRegulatedMarket,
+                  regulatedMarketNote: additionalInformations?.regulatedMarketNote,
+                  establishedByRegulatoryProvision:
+                    additionalInformations?.establishedByRegulatoryProvision,
+                  establishedByRegulatoryProvisionNote:
+                    additionalInformations?.establishedByRegulatoryProvisionNote,
+                  ipa: additionalInformations?.ipa,
+                  ipaCode: additionalInformations?.ipaCode,
+                  otherNote: additionalInformations?.otherNote,
+                }
+              : undefined,
           pspData:
             institutionType === 'PSP'
               ? pspData2pspDataRequest(onboardingFormData as OnboardingFormData)
@@ -691,7 +729,7 @@ function OnboardingComponent({ productId }: { productId: string }) {
     },
     {
       label: 'Additional Info',
-      Component: () => StepAdditionalInfos({ forward, back }),
+      Component: () => StepAdditionalInformations({ forward: forwardWithAdditionalGSPInfo, back }),
     },
     {
       label: 'Inserisci i dati del rappresentante legale',

--- a/src/views/onboarding/components/OnBoardingProductStepDelegates.tsx
+++ b/src/views/onboarding/components/OnBoardingProductStepDelegates.tsx
@@ -194,8 +194,9 @@ export function OnBoardingProductStepDelegates({
             <Trans
               i18nKey="onboardingStep3.bodyDescription1"
               values={{ productTitle: product?.title }}
+              components={{ 1: <br />, 3: <br /> }}
             >
-              {`Puoi aggiungere da uno a tre Amministratori o suoi delegati. <1/> Saranno i responsabili della gestione di {{productTitle}} e presenti nel contratto di adesione come delegati dal Legale Rappresentante.`}
+              {`Puoi aggiungere da uno a tre Amministratori o suoi delegati. <1/> Saranno i responsabili della gestione di {{productTitle}} e presenti nel contratto di <3 />adesione come delegati dal Legale Rappresentante.`}
             </Trans>
           </Typography>
         </Grid>

--- a/src/views/onboarding/components/StepAdditionalInformations.tsx
+++ b/src/views/onboarding/components/StepAdditionalInformations.tsx
@@ -12,26 +12,22 @@ import { useTranslation, Trans } from 'react-i18next';
 import { useEffect, useState } from 'react';
 import { OnboardingStepActions } from '../../../components/OnboardingStepActions';
 import { RadioWithTextField } from '../../../components/RadioWithTextField';
+import { StepperStepComponentProps } from '../../../../types';
 
-type Props = {
-  forward: () => void;
-  back: () => void;
-};
-
-export function StepAdditionalInfos({ forward, back }: Props) {
+export function StepAdditionalInformations({ forward, back }: StepperStepComponentProps) {
   const { t } = useTranslation();
   const theme = useTheme();
 
   const [radioValues, setRadioValues] = useState({
-    isEstabilishedRegulatoryProvision: '',
-    fromBelongsRegulatedMarket: '',
-    isFromIPA: '',
-    isConcessionaireOfPublicService: '',
-    optionalPartyInformations: '',
+    isEstabilishedRegulatoryProvision: undefined,
+    fromBelongsRegulatedMarket: undefined,
+    isFromIPA: undefined,
+    isConcessionaireOfPublicService: undefined,
+    optionalPartyInformations: false,
   });
 
-  const [blockData, setBlockData] = useState<{
-    [field: string]: { openTextField: boolean; textFieldValue: string; errorText: string };
+  const [additionalData, setAdditionalData] = useState<{
+    [field: string]: { openTextField: boolean; textFieldValue: string; choice: boolean };
   }>({});
 
   const [errors, setErrors] = useState<{
@@ -42,11 +38,18 @@ export function StepAdditionalInfos({ forward, back }: Props) {
   const [disabled, setDisabled] = useState<boolean>(false);
 
   useEffect(() => {
-    const isContinueButtonEnabled = Object.entries(radioValues).every(([key, value]) =>
-      key === 'optionalPartyInformations' ? true : value !== ''
-    );
+    const isContinueButtonEnabled =
+      Object.entries(radioValues).every(([key, value]) =>
+        key === 'optionalPartyInformations' ? true : value !== undefined
+      ) || isChecked;
 
-    setDisabled(!isContinueButtonEnabled || Object.values(errors).some((error) => error !== ''));
+    const allFalseAndUnchecked = Object.values(radioValues).every((value) => !value) && !isChecked;
+
+    setDisabled(
+      !isContinueButtonEnabled ||
+        allFalseAndUnchecked ||
+        Object.values(errors).some((error) => error !== '')
+    );
   }, [radioValues, errors, isChecked]);
 
   const handleRadioChange = (field: any, value: any) => {
@@ -65,19 +68,19 @@ export function StepAdditionalInfos({ forward, back }: Props) {
       ...prevErrors,
       [field]: '',
     }));
-    setBlockData((prevBlockData) => ({
-      ...prevBlockData,
+    setAdditionalData((prevAdditionalData) => ({
+      ...prevAdditionalData,
       [field]: {
         openTextField: open,
         textFieldValue: value,
-        errorText: '',
+        choice: false,
       },
     }));
   };
 
   const validateTextField = () => {
     const newErrors = Object.entries(radioValues).reduce((acc, [field]) => {
-      if (blockData[field]?.openTextField && blockData[field]?.textFieldValue === '') {
+      if (additionalData[field]?.openTextField && additionalData[field]?.textFieldValue === '') {
         return {
           ...acc,
           [field]: t(`additionalDataPage.formQuestions.textFields.errors.${field}`),
@@ -88,8 +91,8 @@ export function StepAdditionalInfos({ forward, back }: Props) {
 
     if (
       isChecked &&
-      (!blockData.optionalPartyInformations ||
-        blockData.optionalPartyInformations?.textFieldValue === '')
+      (!additionalData.optionalPartyInformations ||
+        additionalData.optionalPartyInformations?.textFieldValue === '')
     ) {
       setErrors((prevErrors) => ({
         ...prevErrors,
@@ -99,7 +102,7 @@ export function StepAdditionalInfos({ forward, back }: Props) {
       }));
     }
 
-    if (Object.keys(newErrors).length > 0) {
+    if (Object.keys(newErrors).length) {
       setErrors((prevErrors) => ({
         ...prevErrors,
         ...newErrors,
@@ -107,7 +110,17 @@ export function StepAdditionalInfos({ forward, back }: Props) {
       setDisabled(true);
     } else {
       setErrors({});
-      forward();
+
+      const choices = Object.values(radioValues);
+
+      const additionalDataWithChoice = Object.keys(radioValues).reduce(
+        (result, key, index) => ({
+          ...result,
+          [key]: { ...additionalData[key], choice: choices[index] },
+        }),
+        {}
+      );
+      forward(additionalDataWithChoice);
     }
   };
 
@@ -129,9 +142,7 @@ export function StepAdditionalInfos({ forward, back }: Props) {
           title={t('additionalDataPage.formQuestions.estabilishedRegulatoryProvision')}
           label={t('additionalDataPage.formQuestions.textFields.labels.note')}
           field={'isEstabilishedRegulatoryProvision'}
-          onRadioChange={(value: any) =>
-            handleRadioChange('isEstabilishedRegulatoryProvision', value)
-          }
+          onRadioChange={handleRadioChange}
           onTextFieldChange={handleTextFieldChange}
           errorText={errors.isEstabilishedRegulatoryProvision || ''}
         />
@@ -145,7 +156,7 @@ export function StepAdditionalInfos({ forward, back }: Props) {
           }
           label={t('additionalDataPage.formQuestions.textFields.labels.note')}
           field={'fromBelongsRegulatedMarket'}
-          onRadioChange={(value: any) => handleRadioChange('fromBelongsRegulatedMarket', value)}
+          onRadioChange={handleRadioChange}
           onTextFieldChange={handleTextFieldChange}
           errorText={errors.fromBelongsRegulatedMarket || ''}
         />
@@ -154,7 +165,7 @@ export function StepAdditionalInfos({ forward, back }: Props) {
           title={t('additionalDataPage.formQuestions.registratedOnIPA')}
           label={t('additionalDataPage.formQuestions.textFields.labels.ipa')}
           field={'isFromIPA'}
-          onRadioChange={(value: any) => handleRadioChange('isFromIPA', value)}
+          onRadioChange={handleRadioChange}
           onTextFieldChange={handleTextFieldChange}
           errorText={errors.isFromIPA || ''}
         />
@@ -163,9 +174,7 @@ export function StepAdditionalInfos({ forward, back }: Props) {
           title={t('additionalDataPage.formQuestions.concessionaireOfPublicService')}
           label={t('additionalDataPage.formQuestions.textFields.labels.note')}
           field={'isConcessionaireOfPublicService'}
-          onRadioChange={(value: any) =>
-            handleRadioChange('isConcessionaireOfPublicService', value)
-          }
+          onRadioChange={handleRadioChange}
           onTextFieldChange={handleTextFieldChange}
           errorText={errors.isConcessionaireOfPublicService || ''}
         />


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Sending the new additionalInformations object in the submit payload

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In order to persist the new collected additionalInformations for GSP that going to do an adhesion for prod-pagopa
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in local aiming dev environment, the submit goes in 201 statusCode correctly and the payload is in 
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.