### PR TITLE
[SELC-3919] feat: Empty the TextField when unchecking the "other" checkbox and improvements in code logic

### DIFF
--- a/src/views/onboarding/components/StepAdditionalInformations.tsx
+++ b/src/views/onboarding/components/StepAdditionalInformations.tsx
@@ -36,6 +36,7 @@ export function StepAdditionalInformations({ forward, back }: StepperStepCompone
 
   const [isChecked, setIsChecked] = useState<boolean>(false);
   const [disabled, setDisabled] = useState<boolean>(false);
+  const [shrink, setShrink] = useState<boolean>(false);
 
   useEffect(() => {
     const isContinueButtonEnabled = Object.entries(radioValues).every(([key, value]) =>
@@ -188,12 +189,17 @@ export function StepAdditionalInformations({ forward, back }: StepperStepCompone
             onClick={() => {
               handleRadioChange('optionalPartyInformations', !isChecked);
               setIsChecked(!isChecked);
-              if (isChecked) {
+              if (
+                additionalData.optionalPartyInformations?.textFieldValue &&
+                isChecked &&
+                additionalData.optionalPartyInformations?.textFieldValue !== ''
+              ) {
+                setShrink(false);
                 setAdditionalData({
                   ['optionalPartyInformations']: {
                     openTextField: true,
                     textFieldValue: '',
-                    choice: isChecked,
+                    choice: !isChecked,
                   },
                 });
               }
@@ -216,9 +222,23 @@ export function StepAdditionalInformations({ forward, back }: StepperStepCompone
             onChange={(e: any) => {
               handleTextFieldChange(true, 'optionalPartyInformations', e.target.value);
             }}
+            onClick={() => setShrink(true)}
+            onBlur={() => {
+              if (
+                additionalData.optionalPartyInformations?.textFieldValue &&
+                additionalData.optionalPartyInformations?.textFieldValue !== ''
+              ) {
+                setShrink(true);
+              } else {
+                setShrink(false);
+              }
+            }}
             error={!!errors.optionalPartyInformations}
+            InputLabelProps={{
+              shrink,
+            }}
             helperText={errors.optionalPartyInformations || ''}
-            value={isChecked ? additionalData.optionalPartyInformations?.textFieldValue : ''}
+            value={additionalData.optionalPartyInformations?.textFieldValue}
           />
         </Grid>
       </Paper>

--- a/src/views/onboarding/components/StepAdditionalInformations.tsx
+++ b/src/views/onboarding/components/StepAdditionalInformations.tsx
@@ -79,16 +79,27 @@ export function StepAdditionalInformations({ forward, back }: StepperStepCompone
 
   const validateTextField = () => {
     const newErrors = Object.keys(radioValues).reduce((acc, field) => {
-      if (
-        (additionalData[field]?.openTextField && additionalData[field]?.textFieldValue === '') ||
-        (isChecked &&
-          field === 'optionalPartyInformations' &&
-          !additionalData[field]?.textFieldValue)
-      ) {
-        return {
-          ...acc,
-          [field]: t(`additionalDataPage.formQuestions.textFields.errors.${field}`),
-        };
+      switch (field) {
+        case 'optionalPartyInformations':
+          if (isChecked && !additionalData.optionalPartyInformations?.textFieldValue) {
+            return {
+              ...acc,
+              [field]: t(
+                `additionalDataPage.formQuestions.textFields.errors.optionalPartyInformations`
+              ),
+            };
+          }
+          break;
+        default:
+          if (
+            additionalData[field]?.openTextField &&
+            additionalData[field]?.textFieldValue === ''
+          ) {
+            return {
+              ...acc,
+              [field]: t(`additionalDataPage.formQuestions.textFields.errors.${field}`),
+            };
+          }
       }
       return acc;
     }, {});
@@ -177,6 +188,15 @@ export function StepAdditionalInformations({ forward, back }: StepperStepCompone
             onClick={() => {
               handleRadioChange('optionalPartyInformations', !isChecked);
               setIsChecked(!isChecked);
+              if (isChecked) {
+                setAdditionalData({
+                  ['optionalPartyInformations']: {
+                    openTextField: true,
+                    textFieldValue: '',
+                    choice: isChecked,
+                  },
+                });
+              }
             }}
             label={t('additionalDataPage.formQuestions.other')}
             sx={{
@@ -198,6 +218,7 @@ export function StepAdditionalInformations({ forward, back }: StepperStepCompone
             }}
             error={!!errors.optionalPartyInformations}
             helperText={errors.optionalPartyInformations || ''}
+            value={isChecked ? additionalData.optionalPartyInformations?.textFieldValue : ''}
           />
         </Grid>
       </Paper>


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Empty the TextField when unchecking the "other" checkbox and improvements in code logic

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Improvements of the user experience and, with this implementation, we don't risk to send other information string also when user uncheck "other" checkbox

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in local environment, after the checkbox is unchecked, the input is removed
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.