### PR TITLE
[SELC-3919] feat: Empty the TextField when unchecking the "other" checkbox and improvements in code logic + other features

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -66,13 +66,13 @@ export const API = {
   ONBOARDING_POST_LEGALS: {
     URL:
       ENV.ENV === 'DEV'
-        ? ENV.URL_API.ONBOARDING_V2 + '/institutions/onboarding'
+        ? ENV.URL_API.ONBOARDING_V2 + '/v2/institutions/onboarding'
         : ENV.URL_API.ONBOARDING + '/institutions/onboarding',
   },
   ONBOARDING_COMPLETE_REGISTRATION: {
     URL:
       ENV.ENV === 'DEV'
-        ? ENV.URL_API.ONBOARDING_V2 + '/tokens/{{token}}/complete'
+        ? ENV.URL_API.ONBOARDING_V2 + '/v2/tokens/{{token}}/complete'
         : ENV.URL_API.ONBOARDING + '/tokens/{{token}}/complete',
   },
 
@@ -91,7 +91,7 @@ export const API = {
   ONBOARDING_TOKEN_VALIDATION: {
     URL:
       ENV.ENV === 'DEV'
-        ? ENV.URL_API.ONBOARDING_V2 + '/tokens/{{token}}/verify'
+        ? ENV.URL_API.ONBOARDING_V2 + '/v2/tokens/{{token}}/verify'
         : ENV.URL_API.ONBOARDING + '/tokens/{{token}}/verify',
   },
   ONBOARDING_GET_GEOTAXONOMY: {

--- a/src/views/OnBoardingSubProduct/OnBoardingSubProduct.tsx
+++ b/src/views/OnBoardingSubProduct/OnBoardingSubProduct.tsx
@@ -80,6 +80,7 @@ function OnBoardingSubProduct() {
   const [city, setCity] = useState('');
   const [county, setCounty] = useState('');
   const [isCityEditable, setIsCityEditable] = useState(false);
+  const [availablePricingPlanIds, setAvailablePricingPlanIds] = useState<Array<string>>();
 
   useEffect(() => {
     registerUnloadEvent(setOnExit, setOpenExitModal, setOnExitAction);
@@ -209,8 +210,8 @@ function OnBoardingSubProduct() {
     setPartyId(partyId);
     forward();
   };
-  const forwardWitSelectedPricingPlan = (pp: string) => {
-    setPricingPlan(pp);
+  const forwardWitSelectedPricingPlan = (selectedPricingPlan: string) => {
+    setPricingPlan(selectedPricingPlan);
     setActiveStep(parties.length === 0 ? 3 : 2);
     window.scrollTo(0, 0);
   };
@@ -236,6 +237,7 @@ function OnBoardingSubProduct() {
       label: 'Select Pricing Plan',
       Component: () =>
         SubProductStepSelectPricingPlan({
+          setAvailablePricingPlanIds,
           forward: forwardWitSelectedPricingPlan,
           product,
         }),
@@ -394,15 +396,7 @@ function OnBoardingSubProduct() {
     setOnExitAction(undefined);
   };
 
-  return pricingPlan &&
-    pricingPlan !== 'C0' &&
-    pricingPlan !== 'C1' &&
-    pricingPlan !== 'C2' &&
-    pricingPlan !== 'C3' &&
-    pricingPlan !== 'C4' &&
-    pricingPlan !== 'C5' &&
-    pricingPlan !== 'C6' &&
-    pricingPlan !== 'C7' ? (
+  return pricingPlan && !availablePricingPlanIds?.includes(pricingPlan) ? (
     <EndingPage
       minHeight="52vh"
       icon={<IllusError size={60} />}

--- a/src/views/OnBoardingSubProduct/components/subProductStepPricingPlan/SubProductStepSelectPricingPlan.tsx
+++ b/src/views/OnBoardingSubProduct/components/subProductStepPricingPlan/SubProductStepSelectPricingPlan.tsx
@@ -19,14 +19,29 @@ import FooterConsumptionCard from './components/consumptionPlanComponent/FooterC
 
 type Props = StepperStepComponentProps & {
   product?: Product;
+  setAvailablePricingPlanIds: React.Dispatch<React.SetStateAction<Array<string> | undefined>>;
 };
-export default function SubProductStepSelectPricingPlan({ forward, product }: Props) {
+
+export default function SubProductStepSelectPricingPlan({
+  forward,
+  product,
+  setAvailablePricingPlanIds,
+}: Props) {
   const { t } = useTranslation();
   const theme = useTheme();
   const { setRequiredLogin } = useContext(UserContext);
 
   const [openExitModal, setOpenExitModal] = useState<boolean>(false);
   const [plansPrices, setPlansPrices] = useState<PlansPrices>();
+
+  useEffect(() => {
+    if (plansPrices) {
+      const pricingPlanIds = plansPrices?.carnetPlans
+        .map((p) => p.pricingPlan)
+        .concat(plansPrices.consumptionPlan.pricingPlan);
+      setAvailablePricingPlanIds(pricingPlanIds);
+    }
+  }, [plansPrices]);
 
   const onReject = () => {
     setOpenExitModal(true);

--- a/src/views/onboarding/components/StepAdditionalInformations.tsx
+++ b/src/views/onboarding/components/StepAdditionalInformations.tsx
@@ -36,6 +36,7 @@ export function StepAdditionalInformations({ forward, back }: StepperStepCompone
 
   const [isChecked, setIsChecked] = useState<boolean>(false);
   const [disabled, setDisabled] = useState<boolean>(false);
+  const [shrink, setShrink] = useState<boolean>(false);
 
   useEffect(() => {
     const isContinueButtonEnabled = Object.entries(radioValues).every(([key, value]) =>
@@ -79,16 +80,27 @@ export function StepAdditionalInformations({ forward, back }: StepperStepCompone
 
   const validateTextField = () => {
     const newErrors = Object.keys(radioValues).reduce((acc, field) => {
-      if (
-        (additionalData[field]?.openTextField && additionalData[field]?.textFieldValue === '') ||
-        (isChecked &&
-          field === 'optionalPartyInformations' &&
-          !additionalData[field]?.textFieldValue)
-      ) {
-        return {
-          ...acc,
-          [field]: t(`additionalDataPage.formQuestions.textFields.errors.${field}`),
-        };
+      switch (field) {
+        case 'optionalPartyInformations':
+          if (isChecked && !additionalData.optionalPartyInformations?.textFieldValue) {
+            return {
+              ...acc,
+              [field]: t(
+                `additionalDataPage.formQuestions.textFields.errors.optionalPartyInformations`
+              ),
+            };
+          }
+          break;
+        default:
+          if (
+            additionalData[field]?.openTextField &&
+            additionalData[field]?.textFieldValue === ''
+          ) {
+            return {
+              ...acc,
+              [field]: t(`additionalDataPage.formQuestions.textFields.errors.${field}`),
+            };
+          }
       }
       return acc;
     }, {});
@@ -177,6 +189,20 @@ export function StepAdditionalInformations({ forward, back }: StepperStepCompone
             onClick={() => {
               handleRadioChange('optionalPartyInformations', !isChecked);
               setIsChecked(!isChecked);
+              if (
+                additionalData.optionalPartyInformations?.textFieldValue &&
+                isChecked &&
+                additionalData.optionalPartyInformations?.textFieldValue !== ''
+              ) {
+                setShrink(false);
+                setAdditionalData({
+                  ['optionalPartyInformations']: {
+                    openTextField: true,
+                    textFieldValue: '',
+                    choice: !isChecked,
+                  },
+                });
+              }
             }}
             label={t('additionalDataPage.formQuestions.other')}
             sx={{
@@ -196,8 +222,23 @@ export function StepAdditionalInformations({ forward, back }: StepperStepCompone
             onChange={(e: any) => {
               handleTextFieldChange(true, 'optionalPartyInformations', e.target.value);
             }}
+            onClick={() => setShrink(true)}
+            onBlur={() => {
+              if (
+                additionalData.optionalPartyInformations?.textFieldValue &&
+                additionalData.optionalPartyInformations?.textFieldValue !== ''
+              ) {
+                setShrink(true);
+              } else {
+                setShrink(false);
+              }
+            }}
             error={!!errors.optionalPartyInformations}
+            InputLabelProps={{
+              shrink,
+            }}
             helperText={errors.optionalPartyInformations || ''}
+            value={additionalData.optionalPartyInformations?.textFieldValue}
           />
         </Grid>
       </Paper>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Empty the TextField when unchecking the "other" checkbox and improvements in code logic
- V2 version basePath only for DEV environment
- Check on available pricingPlanId based on rest api response

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
For resolve the previous static approach that expect as correct pricingPlanId only those indicated by the condition. With this implementation is used a dynamic approach also for validation of correct pricingPlanId and other implementation used to aiming new v2 basePath REST API temporary only for DEV enviroment

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
All features of this pullrequest has been tested on DEV environment
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.