### PR TITLE
[SELC-4025] fix: hide modal of confimation of onboarding for PT

### DIFF
--- a/src/views/onboarding/Onboarding.tsx
+++ b/src/views/onboarding/Onboarding.tsx
@@ -762,6 +762,7 @@ function OnboardingComponent({ productId }: { productId: string }) {
           product: selectedProduct,
           legal: isTechPartner ? undefined : (formData as any)?.users[0],
           partyName: onboardingFormData?.businessName || '',
+          isTechPartner,
           forward: (newFormData: Partial<FormData>) => {
             const users = (newFormData as any).users as Array<UserOnCreate>;
             const usersWithoutLegal = users.slice(0, 0).concat(users.slice(0 + 1));

--- a/src/views/onboarding/components/OnBoardingProductStepDelegates.tsx
+++ b/src/views/onboarding/components/OnBoardingProductStepDelegates.tsx
@@ -21,6 +21,7 @@ type Props = StepperStepComponentProps & {
   legal?: UserOnCreate;
   externalInstitutionId: string;
   partyName: string;
+  isTechPartner: boolean;
 };
 
 export function OnBoardingProductStepDelegates({
@@ -30,6 +31,7 @@ export function OnBoardingProductStepDelegates({
   forward,
   back,
   partyName,
+  isTechPartner,
 }: Props) {
   const { user, setRequiredLogin } = useContext(UserContext);
   const [_loading, setLoading] = useState(true);
@@ -59,7 +61,12 @@ export function OnBoardingProductStepDelegates({
     const userIds = Object.keys(people);
     if (index === userIds.length) {
       if (Object.keys(peopleErrors).length === 0) {
-        setOpenConfirmationModal(true);
+        // TODO hide modal for PT until copy is changed. Remove if case isTechPartner after copy is changed
+        if (isTechPartner) {
+          onForwardAction();
+        } else {
+          setOpenConfirmationModal(true);
+        }
       }
       setPeopleErrors(peopleErrors);
       setLoading(false);
@@ -68,7 +75,12 @@ export function OnBoardingProductStepDelegates({
     if (!isAuthUser) {
       validateUserData(people[userId], externalInstitutionId, userId, index, peopleErrors);
     } else {
-      setOpenConfirmationModal(true);
+      // TODO hide modal for PT until copy is changed. Remove if case isTechPartner after copy is changed
+      if (isTechPartner) {
+        onForwardAction();
+      } else {
+        setOpenConfirmationModal(true);
+      }
     }
   };
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
hide modal for PT until copy is changed. 
<!--- Describe your changes in detail -->

#### Motivation and Context
Institutions of type PT are not required to sign the contract so the modal should be hidden at the moment for PT until new copy.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.