### PR TITLE
[SELC-3767] feat: forwarding is permitted without selecting only for GPS

### DIFF
--- a/src/components/autocomplete/Autocomplete.tsx
+++ b/src/components/autocomplete/Autocomplete.tsx
@@ -26,6 +26,7 @@ type AutocompleteProps = {
   setAooResultHistory: (t: AooData | undefined) => void;
   externalInstitutionId: string;
   institutionType?: InstitutionType;
+  setDisabled: Dispatch<SetStateAction<boolean>>;
 };
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
@@ -48,6 +49,7 @@ export function Autocomplete({
   setAooResultHistory,
   externalInstitutionId,
   institutionType,
+  setDisabled,
 }: AutocompleteProps) {
   const [options, setOptions] = useState<Array<InstitutionResource>>([]);
   const [cfResult, setCfResult] = useState<InstitutionResource | ANACParty>();
@@ -127,6 +129,7 @@ export function Autocomplete({
           setAooResultHistory={setAooResultHistory}
           externalInstitutionId={externalInstitutionId}
           institutionType={institutionType}
+          setDisabled={setDisabled}
         />
       </Grid>
     </Paper>

--- a/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
@@ -2,7 +2,7 @@ import { Grid, Theme, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import { AxiosError, AxiosResponse } from 'axios';
 import debounce from 'lodash/debounce';
-import { Dispatch, SetStateAction, useContext, useState } from 'react';
+import { Dispatch, SetStateAction, useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ANACParty, Endpoint, InstitutionType, Product } from '../../../../../types';
 import { ReactComponent as PartyIcon } from '../../../../assets/onboarding_party_icon.svg';
@@ -46,6 +46,7 @@ type Props = {
   uoResult?: UoData;
   externalInstitutionId: string;
   institutionType?: InstitutionType;
+  setDisabled: Dispatch<SetStateAction<boolean>>;
 };
 
 // TODO: handle cognitive-complexity
@@ -78,6 +79,7 @@ export default function AsyncAutocompleteContainer({
   setAooResultHistory,
   externalInstitutionId,
   institutionType,
+  setDisabled,
 }: Props) {
   const { setRequiredLogin } = useContext(UserContext);
   const { t } = useTranslation();
@@ -97,6 +99,20 @@ export default function AsyncAutocompleteContainer({
       : institutionType === 'GSP'
       ? 'L37,SAG'
       : 'C17,C16,L10,L19,L13,L2,C10,L20,L21,L22,L15,L1,C13,C5,L40,L11,L39,L46,L8,L34,L7,L35,L45,L47,L6,L12,L24,L28,L42,L36,L44,C8,C3,C7,C14,L16,C11,L33,C12,L43,C2,L38,C1,L5,L4,L31,L18,L17,S01,SA';
+
+  useEffect(() => {
+    const disabledButton =
+      institutionType === 'GSP' && product?.id !== 'prod-interop'
+        ? isBusinessNameSelected
+          ? input.length < 3
+          : isTaxCodeSelected
+          ? input.length < 11
+          : isAooCodeSelected
+          ? !!aooResult
+          : !!uoResult
+        : !selected;
+    setDisabled(disabledButton);
+  }, [input, options, selected]);
 
   const handleSearchByName = async (
     query: string,

--- a/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
@@ -100,19 +100,24 @@ export default function AsyncAutocompleteContainer({
       ? 'L37,SAG'
       : 'C17,C16,L10,L19,L13,L2,C10,L20,L21,L22,L15,L1,C13,C5,L40,L11,L39,L46,L8,L34,L7,L35,L45,L47,L6,L12,L24,L28,L42,L36,L44,C8,C3,C7,C14,L16,C11,L33,C12,L43,C2,L38,C1,L5,L4,L31,L18,L17,S01,SA';
 
+  const disabledButton =
+    institutionType === 'GSP' && product?.id !== 'prod-interop'
+      ? isBusinessNameSelected
+        ? input.length < 3
+        : isTaxCodeSelected
+        ? input.length < 11
+        : isAooCodeSelected
+        ? !!aooResult
+        : !!uoResult
+      : !selected;
+
   useEffect(() => {
-    const disabledButton =
-      institutionType === 'GSP' && product?.id !== 'prod-interop'
-        ? isBusinessNameSelected
-          ? input.length < 3
-          : isTaxCodeSelected
-          ? input.length < 11
-          : isAooCodeSelected
-          ? !!aooResult
-          : !!uoResult
-        : !selected;
-    setDisabled(disabledButton);
-  }, [input, options, selected]);
+    if (input) {
+      setDisabled(disabledButton);
+    } else {
+      setDisabled(!selected);
+    }
+  }, [input, selected]);
 
   const handleSearchByName = async (
     query: string,

--- a/src/components/autocomplete/components/asyncAutocomplete/components/AsyncAutocompleteSearch.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/components/AsyncAutocompleteSearch.tsx
@@ -120,7 +120,7 @@ export default function AsyncAutocompleteSearch({
               ? t('asyncAutocomplete.aooLabel')
               : isUoCodeSelected
               ? t('asyncAutocomplete.uoLabel')
-              : t('asyncAutocomplete.serachLabel')
+              : t('asyncAutocomplete.searchLabel')
             : ''
         }
         variant={!selected ? 'outlined' : 'standard'}
@@ -133,7 +133,7 @@ export default function AsyncAutocompleteSearch({
             lineHeight: '24px',
             color: theme.palette.text.primary,
             textAlign: 'start',
-            paddingLeft: '8px',
+            paddingLeft: '16px',
             ...(selected && {
               ...truncatedText,
               WebkitLineClamp: 1,

--- a/src/components/steps/StepSearchParty.tsx
+++ b/src/components/steps/StepSearchParty.tsx
@@ -168,19 +168,32 @@ export function StepSearchParty({
     setAooResultHistory(aooResult);
     setUoResultHistory(uoResult);
     setSelectedHistory(selected);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const { id } = selected!;
-    forward(
-      {
-        externalId: dataFromAooUo ? dataFromAooUo.id : id,
-      },
-      aooResult || uoResult
-        ? ({ ...dataFromAooUo } as Party)
-        : ({ ...selected, externalId: id } as Party),
-      aooResult,
-      uoResult,
-      institutionType
-    );
+
+    if (
+      !selected?.id &&
+      institutionType === 'GSP' &&
+      (product?.id === 'prod-io' || product?.id === 'prod-pagopa')
+    ) {
+      forward(
+        { externalId: '' },
+        { ...selected, externalId: '' } as Party,
+        aooResult,
+        uoResult,
+        institutionType
+      );
+    } else {
+      forward(
+        {
+          externalId: dataFromAooUo ? dataFromAooUo.id : selected?.id,
+        },
+        aooResult || uoResult
+          ? ({ ...dataFromAooUo } as Party)
+          : ({ ...selected, externalId: selected?.id } as Party),
+        aooResult,
+        uoResult,
+        institutionType
+      );
+    }
   };
 
   const { t } = useTranslation();
@@ -391,7 +404,7 @@ export function StepSearchParty({
                             color: theme.palette.primary.main,
                             cursor: 'pointer',
                           }}
-                          href={forward}
+                          onClick={onForwardAction}
                         />
                       ),
                     }}

--- a/src/components/steps/StepSearchParty.tsx
+++ b/src/components/steps/StepSearchParty.tsx
@@ -87,6 +87,7 @@ export function StepSearchParty({
     null
   );
   const [dataFromAooUo, setDataFromAooUo] = useState<IPACatalogParty | null>();
+  const [disabled, setDisabled] = useState<boolean>(false);
 
   const handleSearchTaxCodeFromAooUo = async (query: string) => {
     const searchResponse = await fetchWithLogs(
@@ -335,6 +336,7 @@ export function StepSearchParty({
           <Autocomplete
             theme={theme}
             selected={selected}
+            setDisabled={setDisabled}
             setSelected={setSelected}
             endpoint={{ endpoint: 'ONBOARDING_GET_SEARCH_PARTIES' }}
             transformFn={(data: { items: Array<IPACatalogParty> }) =>
@@ -374,21 +376,48 @@ export function StepSearchParty({
                 sx={{
                   textAlign: 'center',
                 }}
-                variant="caption"
-                color={theme.palette.text.primary}
+                variant="body1"
+                color={theme.palette.text.secondary}
               >
-                <Trans i18nKey="onboardingStep1.onboarding.ipaDescription">
-                  Non trovi il tuo ente nell&apos;IPA? In
-                  <Link
-                    sx={{ textDecoration: 'none', color: theme.palette.primary.main }}
-                    href="https://indicepa.gov.it/ipa-portale/servizi-enti/accreditamento-ente"
+                {institutionType === 'GSP' && product?.id !== 'prod-interop' ? (
+                  <Trans
+                    i18nKey="onboardingStep1.onboarding.gpsDescription"
+                    components={{
+                      1: <br />,
+                      2: (
+                        <Link
+                          sx={{
+                            textDecoration: 'underline',
+                            color: theme.palette.primary.main,
+                            cursor: 'pointer',
+                          }}
+                          href={forward}
+                        />
+                      ),
+                    }}
                   >
-                    questa pagina
-                  </Link>
-                  trovi maggiori
-                  <br />
-                  informazioni sull&apos;indice e su come accreditarsi
-                </Trans>
+                    {`Non trovi il tuo ente nell'IPA?<1 /><2>Inserisci manualmente i dati del tuo ente.</2>`}
+                  </Trans>
+                ) : (
+                  <Trans
+                    i18nKey="onboardingStep1.onboarding.ipaDescription"
+                    components={{
+                      1: (
+                        <Link
+                          sx={{
+                            textDecoration: 'none',
+                            color: theme.palette.primary.main,
+                            cursor: 'pointer',
+                          }}
+                          href="https://indicepa.gov.it/ipa-portale/servizi-enti/accreditamento-ente"
+                        />
+                      ),
+                      3: <br />,
+                    }}
+                  >
+                    {`Non trovi il tuo ente nell'IPA? In <1>questa pagina</1> trovi maggiori <3/> informazioni sull'indice e su come accreditarsi `}
+                  </Trans>
+                )}
               </Typography>
             </Box>
           </Grid>
@@ -408,7 +437,7 @@ export function StepSearchParty({
           forward={{
             action: onForwardAction,
             label: t('onboardingStep1.onboarding.onboardingStepActions.confirmAction'),
-            disabled: !selected,
+            disabled,
           }}
         />
       </Grid>

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -9,7 +9,7 @@ export default {
     noResultsLabel: 'Nessun risultato',
     lessThen3CharacterLabel: 'Digita almeno 3 caratteri',
     lessThen11CharacterLabel: 'Digita almeno 11 caratteri',
-    serachLabel: 'Cerca ente',
+    searchLabel: 'Cerca ente',
     aooLabel: 'Inserisci il codice univoco AOO',
     uoLabel: 'Inserisci il codice univoco UO',
     ariaLabel: `Seleziona la tipologia di ricerca dell'ente`,
@@ -94,6 +94,7 @@ export default {
       bodyDescription:
         'Inserisci uno dei dati richiesti e cerca dall’Indice della Pubblica <1/> Amministrazione (IPA) l’ente per cui vuoi richiedere l’adesione a <3/>{{productTitle}}',
       ipaDescription: `Non trovi il tuo ente nell'IPA? In <1>questa pagina</1> trovi maggiori <3/> informazioni sull'indice e su come accreditarsi `,
+      gpsDescription: `Non trovi il tuo ente nell'IPA?<1 /><2>Inserisci manualmente i dati del tuo ente.</2>`,
       saSubTitle:
         'Se sei tra i gestori privati di piattaforma e-procurement e hai <1/> già ottenuto la <3>certificazione da AgID</3>, inserisci uno dei dati <5/> richiesti e cerca l’ente per cui vuoi richiedere l’adesione a <7/> Interoperabilità.',
       asSubTitle:

--- a/src/views/onboarding/Onboarding.tsx
+++ b/src/views/onboarding/Onboarding.tsx
@@ -598,8 +598,9 @@ function OnboardingComponent({ productId }: { productId: string }) {
     setInstitutionType(newInstitutionType);
     forward();
     if (
-      (newInstitutionType === 'PSP' || newInstitutionType !== 'PA') &&
-      productId !== 'prod-interop'
+      newInstitutionType !== 'GSP' &&
+      newInstitutionType !== 'PA' &&
+      newInstitutionType !== 'SA'
     ) {
       if (newInstitutionType !== institutionType) {
         setOnboardingFormData({

--- a/src/views/onboarding/Onboarding.tsx
+++ b/src/views/onboarding/Onboarding.tsx
@@ -600,7 +600,8 @@ function OnboardingComponent({ productId }: { productId: string }) {
     if (
       newInstitutionType !== 'GSP' &&
       newInstitutionType !== 'PA' &&
-      newInstitutionType !== 'SA'
+      newInstitutionType !== 'SA' &&
+      newInstitutionType !== 'AS'
     ) {
       if (newInstitutionType !== institutionType) {
         setOnboardingFormData({
@@ -727,7 +728,7 @@ function OnboardingComponent({ productId }: { productId: string }) {
               setOpenExitModal(true);
             } else if (
               institutionType === 'PSP' ||
-              (institutionType !== 'PA' && institutionType !== 'SA')
+              (institutionType !== 'PA' && institutionType !== 'SA' && institutionType !== 'GSP')
             ) {
               setActiveStep(0);
             } else {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Forwarding is permitted without selecting only for GPS

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The search for GPS from the IPA database has also been included for the GPS belonging to the app-io and prod-pagopa products. A banner has been added to allow the search step to be skipped. When the search fails, the continue button will be enabled.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in DEV ensuring all the cases and logic are covered. Tested, also, with a E2E, submitting correctly an onboarding request and, then approve it in admin overview
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.