### PR TITLE
[SELC-3966] Feat: Modal for handling generic errror vat number verification

### DIFF
--- a/src/components/onboardingFormData/ErrorPIVAModal.tsx
+++ b/src/components/onboardingFormData/ErrorPIVAModal.tsx
@@ -1,0 +1,26 @@
+import { SessionModal } from '@pagopa/selfcare-common-frontend';
+import { useTranslation } from 'react-i18next';
+import { ENV } from '../../utils/env';
+
+type ErrorModalProps = {
+  openVatNumberErrorModal: boolean;
+  setOpenVatNumberErrorModal: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export const ErrorModalVatNumber = ({
+  openVatNumberErrorModal,
+  setOpenVatNumberErrorModal,
+}: ErrorModalProps) => {
+  const { t } = useTranslation();
+  return (
+    <SessionModal
+      open={openVatNumberErrorModal}
+      title={t('onboardingFormData.billingDataSection.vatNumberVerificationErrorTitle')}
+      message={t('onboardingFormData.billingDataSection.vatNumberVerificationErrorDescription')}
+      onCloseLabel={t('onboardingFormData.backLabel')}
+      onConfirmLabel={t('onboardingFormData.closeBtnLabel')}
+      onConfirm={() => window.location.assign(ENV.URL_FE.DASHBOARD)}
+      handleClose={() => setOpenVatNumberErrorModal(false)}
+    ></SessionModal>
+  );
+};

--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -33,6 +33,7 @@ import PersonalAndBillingDataSection from '../onboardingFormData/PersonalAndBill
 import GeoTaxSessionModal from '../onboardingFormData/taxonomy/GeoTaxSessionModal';
 import GeoTaxonomySection from '../onboardingFormData/taxonomy/GeoTaxonomySection';
 import { useHistoryState } from '../useHistoryState';
+import { ErrorModalVatNumber } from '../onboardingFormData/ErrorPIVAModal';
 
 const fiscalAndVatCodeRegexp = new RegExp(
   /(^[A-Za-z]{6}[0-9lmnpqrstuvLMNPQRSTUV]{2}[abcdehlmprstABCDEHLMPRST]{1}[0-9lmnpqrstuvLMNPQRSTUV]{2}[A-Za-z]{1}[0-9lmnpqrstuvLMNPQRSTUV]{3}[A-Za-z]{1}$|^[0-9]{11}$)/
@@ -94,8 +95,9 @@ export default function StepOnboardingFormData({
 
   const [openModifyModal, setOpenModifyModal] = useState<boolean>(false);
   const [openAddModal, setOpenAddModal] = useState<boolean>(false);
-  const [isVatRegistrated, setIsVatRegistrated] = useState<boolean>(false);
+  const [openVatNumberErrorModal, setOpenVatNumberErrorModal] = useState<boolean>(false);
   const [vatVerificationGenericError, setVatVerificationGenericError] = useState<boolean>(false);
+  const [isVatRegistrated, setIsVatRegistrated] = useState<boolean>(false);
   const [previousGeotaxononomies, setPreviousGeotaxononomies] = useState<Array<GeographicTaxonomy>>(
     []
   );
@@ -337,7 +339,7 @@ export default function StepOnboardingFormData({
             : isVatRegistrated
             ? t('onboardingFormData.billingDataSection.vatNumberAlreadyRegistered')
             : vatVerificationGenericError
-            ? t('onboardingFormData.billingDataSection.vatNumberVerificationError')
+            ? requiredError
             : undefined,
         city: !values.city ? requiredError : undefined,
         county: !values.county ? requiredError : undefined,
@@ -466,12 +468,13 @@ export default function StepOnboardingFormData({
     const restOutcome = getFetchOutcome(onboardingStatus);
 
     if (restOutcome === 'success') {
-      setIsVatRegistrated(true);
       setVatVerificationGenericError(false);
+      setIsVatRegistrated(true);
     } else if ((onboardingStatus as AxiosError).response?.status === 404) {
       setIsVatRegistrated(false);
       setVatVerificationGenericError(false);
     } else {
+      setOpenVatNumberErrorModal(true);
       setVatVerificationGenericError(true);
     }
   };
@@ -614,6 +617,10 @@ export default function StepOnboardingFormData({
         openAddModal={openAddModal}
         onForwardAction={onForwardAction}
         handleClose={handleClose}
+      />
+      <ErrorModalVatNumber
+        openVatNumberErrorModal={openVatNumberErrorModal}
+        setOpenVatNumberErrorModal={setOpenVatNumberErrorModal}
       />
     </Box>
   );

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -448,6 +448,7 @@ export default {
     pspAndProdPagoPATitle: 'Inserisci i dati',
     backLabel: 'Indietro',
     confirmLabel: 'Continua',
+    closeBtnLabel: 'Chiudi',
     billingDataPt: {
       title: 'Inserisci i dati',
       subTitle: 'Inserisci le informazioni richieste, assicurandoti che siano corrette.',
@@ -462,7 +463,9 @@ export default {
       invalidMailSupport: 'L’indirizzo email non è valido',
       invalidShareCapitalField: 'Il campo capitale sociale non è valido',
       vatNumberAlreadyRegistered: 'La P. IVA che hai inserito è già stata registrata.',
-      vatNumberVerificationError: 'Non è stato possibile verificare la P.IVA',
+      vatNumberVerificationErrorTitle: 'La verifica non è andata a buon fine',
+      vatNumberVerificationErrorDescription:
+        'Non è stato possibile verificare la P.IVA al momento. Riprova più tardi.',
       centralPartyLabel: 'Ente centrale',
       businessName: 'Ragione sociale',
       aooName: 'Denominazione AOO',


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
In  the onboarding flow to prod-fd add a modal in case of generic error from BE during verification of vat number.. 
<!--- Describe your changes in detail -->

#### Motivation and Context
For techincal problems with the product fiddeiussioni the BE returns status code 500. Add modal that allows redirct to select institutions in dashboard. 
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.