### PR TITLE
[SELC-4263] Feat: change maxlength of IPA code input to 16

### DIFF
--- a/src/components/RadioWithTextField.tsx
+++ b/src/components/RadioWithTextField.tsx
@@ -127,7 +127,7 @@ export function RadioWithTextField({
                 color: theme.palette.text.secondary,
                 marginBottom: field === 'isFromIPA' ? 3 : 0,
               }}
-              inputProps={{ maxLength: field === 'isFromIPA' ? 6 : 300 }}
+              inputProps={{ maxLength: field === 'isFromIPA' ? 16 : 300 }}
               onChange={(e: any) => {
                 onTextFieldChange(true, field, e.target.value);
               }}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
change max lentgth if input field ipa code to 16.
<!--- Describe your changes in detail -->

#### Motivation and Context
During onboarding of gsp into prod-pagopa if the gsp is from ipa its required to compile ipa code input field. IPA code can be longer than the previus limit of 6 charachters
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.