### PR TITLE
Disable api call of verify vat number in order to allow testing for prod-fd

### DIFF
--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -125,7 +125,7 @@ export default function StepOnboardingFormData({
     institutionType !== 'PT' &&
     (productId === 'prod-io' || productId === 'prod-io-sign');
   const isProdIoSign = productId === 'prod-io-sign';
-  const isProdFideiussioni = productId?.startsWith('prod-fd') ?? false;
+  // const isProdFideiussioni = productId?.startsWith('prod-fd') ?? false;
   const isProdInterop = productId === 'prod-interop';
   const aooCode = aooSelected?.codiceUniAoo;
   const uoCode = uoSelected?.codiceUniUo;
@@ -497,7 +497,7 @@ export default function StepOnboardingFormData({
       });
     }
   }, [formik.values.taxCode, formik.values.vatNumber]);
-
+  /*
   useEffect(() => {
     if (
       (isProdFideiussioni && formik.values.vatNumber.length === 11) ||
@@ -505,10 +505,10 @@ export default function StepOnboardingFormData({
         stepHistoryState.isTaxCodeEquals2PIVA &&
         formik.values.taxCode.length === 11)
     ) {
-      void verifyVatNumber();
+       void verifyVatNumber();
     }
   }, [formik.values.vatNumber, stepHistoryState.isTaxCodeEquals2PIVA]);
-
+*/
   const baseTextFieldProps = (
     field: keyof OnboardingFormData,
     label: string,

--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -3,7 +3,7 @@
 
 import { Grid, TextField, Typography } from '@mui/material';
 import { Box, styled } from '@mui/system';
-import { AxiosError, AxiosResponse } from 'axios';
+import { AxiosResponse } from 'axios';
 import { theme } from '@pagopa/mui-italia';
 import { emailRegexp } from '@pagopa/selfcare-common-frontend/utils/constants';
 import { useFormik } from 'formik';
@@ -96,8 +96,8 @@ export default function StepOnboardingFormData({
   const [openModifyModal, setOpenModifyModal] = useState<boolean>(false);
   const [openAddModal, setOpenAddModal] = useState<boolean>(false);
   const [openVatNumberErrorModal, setOpenVatNumberErrorModal] = useState<boolean>(false);
-  const [vatVerificationGenericError, setVatVerificationGenericError] = useState<boolean>(false);
-  const [isVatRegistrated, setIsVatRegistrated] = useState<boolean>(false);
+  const [vatVerificationGenericError, _setVatVerificationGenericError] = useState<boolean>(false);
+  const [isVatRegistrated, _setIsVatRegistrated] = useState<boolean>(false);
   const [previousGeotaxononomies, setPreviousGeotaxononomies] = useState<Array<GeographicTaxonomy>>(
     []
   );
@@ -445,7 +445,7 @@ export default function StepOnboardingFormData({
     vatVerificationGenericError,
     formik.values,
   ]);
-
+  /*
   const verifyVatNumber = async () => {
     const onboardingStatus = await fetchWithLogs(
       {
@@ -478,7 +478,7 @@ export default function StepOnboardingFormData({
       setVatVerificationGenericError(true);
     }
   };
-
+*/
   useEffect(() => {
     if (
       !stepHistoryState.isTaxCodeEquals2PIVA &&


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Comment api verifyVatNumber
<!--- Describe your changes in detail -->

#### Motivation and Context
In order to allow testing for prod-fd since verifyVatNumber always gives error atm
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.