### PR TITLE
[SELC-4481] Feat: substitute deprecated api call instituion-info

### DIFF
--- a/.env.development.local
+++ b/.env.development.local
@@ -9,7 +9,7 @@ REACT_APP_URL_FE_LANDING=http://selfcare/landing
 REACT_APP_URL_FE_ASSISTANCE=http://selfcare/assistance
 
 REACT_APP_URL_API_ONBOARDING=https://api.dev.selfcare.pagopa.it/onboarding/v1
-REACT_APP_URL_API_ONBOARDING_V2=https://api.dev.selfcare.pagopa.it/onboarding/v2
+REACT_APP_URL_API_ONBOARDING_V2=https://api.dev.selfcare.pagopa.it/onboarding
 REACT_APP_URL_API_PARTY_REGISTRY_PROXY=https://api.dev.selfcare.pagopa.it/party-registry-proxy/v1
 
 REACT_APP_URL_GEOTAXONOMY= https://api.dev.selfcare.pagopa.it/external/geotaxonomy

--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -343,7 +343,8 @@ export default function PersonalAndBillingDataSection({
                 }}
                 inputValue={formik.values.city || ''}
                 onChange={(_e: any, selected: any) => {
-                  formik.setFieldValue('city', selected?.city || ''); // handle undefined case
+                  formik.setFieldValue('city', selected?.city || '');
+                  formik.setFieldValue('county', selected?.city || '');
                   if (selected) {
                     setInstitutionLocationData(selected);
                     setIsCitySelected(true);
@@ -354,6 +355,7 @@ export default function PersonalAndBillingDataSection({
                 onBlur={() => {
                   if (!isCitySelected) {
                     setCountries(undefined);
+
                     setInstitutionLocationData(undefined);
                   }
                 }}

--- a/src/components/steps/StepOnboardingData.tsx
+++ b/src/components/steps/StepOnboardingData.tsx
@@ -108,7 +108,7 @@ function StepOnboardingData({
               .charAt(0)
               .toUpperCase()
               .concat(result.institution.city.substring(1).toLowerCase().trim())
-          : undefined,
+          : result.institution.city,
         result.institution.county
       );
     } else if (

--- a/src/components/steps/StepOnboardingData.tsx
+++ b/src/components/steps/StepOnboardingData.tsx
@@ -25,6 +25,7 @@ type Props = StepperStepComponentProps & {
   institutionType?: InstitutionType;
   aooSelected?: AooData;
   uoSelected?: UoData;
+  subProductFlow?: boolean;
 };
 
 const genericError: RequestOutcomeMessage = {
@@ -60,6 +61,7 @@ function StepOnboardingData({
   institutionType,
   aooSelected,
   uoSelected,
+  subProductFlow,
 }: Props) {
   const { t } = useTranslation();
 
@@ -74,16 +76,20 @@ function StepOnboardingData({
     const onboardingData = await fetchWithLogs(
       {
         endpoint: 'ONBOARDING_GET_ONBOARDING_DATA',
-        endpointParams: {
-          externalInstitutionId: aooSelected
-            ? `${externalInstitutionId}_${aooSelected.codiceUniAoo}`
+      },
+
+      {
+        method: 'GET',
+        params: {
+          taxCode: externalInstitutionId,
+          subunitCode: aooSelected
+            ? aooSelected.codiceUniAoo
             : uoSelected
-            ? `${externalInstitutionId}_${uoSelected.codiceUniUo}`
-            : externalInstitutionId,
+            ? uoSelected.codiceUniUo
+            : undefined,
           productId,
         },
       },
-      { method: 'GET' },
       () => setRequiredLogin(true)
     );
 
@@ -102,7 +108,7 @@ function StepOnboardingData({
               .charAt(0)
               .toUpperCase()
               .concat(result.institution.city.substring(1).toLowerCase().trim())
-          : result.institution.city,
+          : undefined,
         result.institution.county
       );
     } else if (
@@ -117,8 +123,13 @@ function StepOnboardingData({
   };
 
   useEffect(() => {
-    void submit();
-  }, []);
+    if (subProductFlow === true) {
+      void submit();
+    } else {
+      forward(undefined, institutionType, undefined);
+      setLoading(false);
+    }
+  }, [productId]);
 
   if (outcome) {
     unregisterUnloadEvent(setOnExit);

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -895,9 +895,9 @@ export async function mockFetch(
 
   if (endpoint === 'ONBOARDING_GET_ONBOARDING_DATA') {
     const onboardingData = mockedOnboardingData.find(
-      (od) => od.institution.billingData.taxCode === endpointParams.externalInstitutionId
+      (od) => od.institution.billingData.taxCode === params.taxCode
     );
-    if (endpointParams.externalInstitutionId === '92078570527') {
+    if (params.taxCode === '92078570527') {
       return new Promise((resolve) =>
         resolve({ data: onboardingData, status: 200, statusText: '200' } as AxiosResponse)
       );

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -77,7 +77,7 @@ export const API = {
   ONBOARDING_GET_ONBOARDING_DATA: {
     URL:
       ENV.URL_API.ONBOARDING +
-      '/institutions/{{externalInstitutionId}}/products/{{productId}}/onboarded-institution-info',
+      '/institutions/onboarding/',
   },
   ONBOARDING_USER_VALIDATION: {
     URL: ENV.URL_API.ONBOARDING + '/users/validate',

--- a/src/views/OnBoardingSubProduct/OnBoardingSubProduct.tsx
+++ b/src/views/OnBoardingSubProduct/OnBoardingSubProduct.tsx
@@ -76,9 +76,6 @@ function OnBoardingSubProduct() {
   const [companyInformations, setCompanyInformations] = useState<CompanyInformations>();
   const [openConfirmationModal, setOpenConfirmationModal] = useState(false);
   const [partyName, setPartyName] = useState('');
-  const [country, setCountry] = useState('');
-  const [city, setCity] = useState('');
-  const [county, setCounty] = useState('');
   const [isCityEditable, setIsCityEditable] = useState(false);
   const [availablePricingPlanIds, setAvailablePricingPlanIds] = useState<Array<string>>();
 
@@ -145,6 +142,9 @@ function OnBoardingSubProduct() {
       vatNumber: '',
       recipientCode: party.origin === 'IPA' ? party.originId : '',
       geographicTaxonomies: [],
+      city: '',
+      country: '',
+      county: '',
     });
     const event = isUserParty
       ? 'ONBOARDING_PREMIUM_ASSOCIATED_PARTY_SELECTION'
@@ -173,7 +173,12 @@ function OnBoardingSubProduct() {
     setStepAddManagerHistoryState({});
 
     if (billingData) {
-      setBillingData(billingData);
+      setBillingData({
+        ...billingData,
+        city,
+        country,
+        county,
+      });
     }
     if (assistanceContacts) {
       setAssistanceContacts(assistanceContacts);
@@ -182,18 +187,10 @@ function OnBoardingSubProduct() {
       setCompanyInformations(companyInformations);
     }
 
-    if (country) {
-      setCountry(country);
-    }
-    if (city) {
-      setCity(city);
-    }
-    if (!city) {
+    if (!billingData?.city) {
       setIsCityEditable(true);
     }
-    if (county) {
-      setCounty(county);
-    }
+
     setInstitutionType(institutionType);
     setPartyId(partyId);
     forward();
@@ -295,6 +292,7 @@ function OnBoardingSubProduct() {
           externalInstitutionId,
           productId,
           forward: forwardWithOnboardingData,
+          subProductFlow: true,
         }),
     },
     {
@@ -316,12 +314,12 @@ function OnBoardingSubProduct() {
               vatNumber: '',
               recipientCode: '',
               geographicTaxonomies: [],
+              city: '',
+              county: '',
+              country: '',
             }),
             ...assistanceContacts,
             ...companyInformations,
-            city: city ?? '',
-            county: county ?? '',
-            country: country ?? '',
           },
           institutionType: institutionType as InstitutionType,
           origin,

--- a/src/views/onboarding/__tests__/Onboarding.test.tsx
+++ b/src/views/onboarding/__tests__/Onboarding.test.tsx
@@ -455,7 +455,7 @@ const executeAdvancedSearchForAoo = async () => {
   expect(confirmButton).toBeEnabled();
 
   fireEvent.click(confirmButton);
-  await waitFor(() => expect(fetchWithLogsSpy).toBeCalledTimes(7));
+  await waitFor(() => expect(fetchWithLogsSpy).toBeCalledTimes(6));
 
   const aooCode = document.getElementById('aooUniqueCode') as HTMLInputElement;
   const aooName = document.getElementById('aooName') as HTMLInputElement;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Substitute deprecated api /onboarded-institution-info with /onboarding?taxCode&productId
<!--- Describe your changes in detail -->

#### Motivation and Context
To have the fields city and county prefilled a new api was called only for the sub product onboarding flow.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested locally by aiming at dev data
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.