### PR TITLE
[SELC-4752] feat: Removed "party not have vatNumber" for fideiussioni and fideiussioni garantito products

### DIFF
--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -50,6 +50,7 @@ type Props = StepperStepComponentProps & {
   uoSelected?: UoData;
   institutionAvoidGeotax: boolean;
   selectedParty?: Party;
+  productId?: string;
   retrievedIstat?: string;
   isCityEditable?: boolean;
   isRecipientCodeVisible: boolean;
@@ -74,6 +75,7 @@ export default function PersonalAndBillingDataSection({
   isCityEditable,
   isRecipientCodeVisible,
   isForeignInsurance,
+  productId,
 }: Props) {
   const { t } = useTranslation();
   const { setRequiredLogin } = useContext(UserContext);
@@ -651,43 +653,45 @@ export default function PersonalAndBillingDataSection({
                     </Box>
                   </Grid>
                 )}
-              <Grid item>
-                <Box
-                  display="flex"
-                  alignItems="center"
-                  marginBottom={!formik.values.hasVatnumber && isRecipientCodeVisible ? -2 : 0}
-                >
-                  <Checkbox
-                    id="party_without_vatnumber"
-                    inputProps={{
-                      'aria-label': t(
-                        'onboardingFormData.billingDataSection.partyWithoutVatNumber'
-                      ),
-                    }}
-                    onChange={(e) => {
-                      formik.setFieldValue('hasVatnumber', !e.target.checked);
-                      setStepHistoryState({
-                        ...stepHistoryState,
-                        isTaxCodeEquals2PIVA: false,
-                      });
-                    }}
-                  />
-                  <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                    <Typography component={'span'}>
-                      {t('onboardingFormData.billingDataSection.partyWithoutVatNumber')}
-                    </Typography>
-                    <Typography variant={'caption'} sx={{ fontWeight: '400', color: '#5C6F82' }}>
-                      <Trans
-                        i18nKey="onboardingFormData.billingDataSection.partyWIthoutVatNumberSubtitle"
-                        components={{ 1: <br /> }}
-                      >
-                        {`Indica solo il Codice Fiscale se il tuo ente non agisce nell'esercizio d'impresa,
+              {productId !== 'prod-fd' && productId !== 'prod-fd-garantito' && (
+                <Grid item>
+                  <Box
+                    display="flex"
+                    alignItems="center"
+                    marginBottom={!formik.values.hasVatnumber && isRecipientCodeVisible ? -2 : 0}
+                  >
+                    <Checkbox
+                      id="party_without_vatnumber"
+                      inputProps={{
+                        'aria-label': t(
+                          'onboardingFormData.billingDataSection.partyWithoutVatNumber'
+                        ),
+                      }}
+                      onChange={(e) => {
+                        formik.setFieldValue('hasVatnumber', !e.target.checked);
+                        setStepHistoryState({
+                          ...stepHistoryState,
+                          isTaxCodeEquals2PIVA: false,
+                        });
+                      }}
+                    />
+                    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                      <Typography component={'span'}>
+                        {t('onboardingFormData.billingDataSection.partyWithoutVatNumber')}
+                      </Typography>
+                      <Typography variant={'caption'} sx={{ fontWeight: '400', color: '#5C6F82' }}>
+                        <Trans
+                          i18nKey="onboardingFormData.billingDataSection.partyWIthoutVatNumberSubtitle"
+                          components={{ 1: <br /> }}
+                        >
+                          {`Indica solo il Codice Fiscale se il tuo ente non agisce nell'esercizio d'impresa,
                 arte o professione <1 />(cfr. art. 21, comma 2, lett. f, DPR n. 633/1972)`}
-                      </Trans>
-                    </Typography>
+                        </Trans>
+                      </Typography>
+                    </Box>
                   </Box>
-                </Box>
-              </Grid>
+                </Grid>
+              )}
             </Grid>
           )}
 
@@ -708,7 +712,10 @@ export default function PersonalAndBillingDataSection({
                   onClick={() => setShrinkVatNumber(true)}
                   onBlur={() => setShrinkVatNumber(false)}
                   InputLabelProps={{
-                    shrink: shrinkVatNumber || stepHistoryState.isTaxCodeEquals2PIVA,
+                    shrink:
+                      shrinkVatNumber ||
+                      stepHistoryState.isTaxCodeEquals2PIVA ||
+                      formik.values.vatNumber,
                   }}
                 />
               )}

--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -578,6 +578,7 @@ export default function StepOnboardingFormData({
           </Grid>
         </Grid>
         <PersonalAndBillingDataSection
+          productId={productId}
           origin={origin}
           institutionType={institutionType}
           baseTextFieldProps={baseTextFieldProps}


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
[SELC-4752] feat: Removed "party not have vatNumber" for fideiussioni and fideiussioni garantito products

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The adhesions for product fideiussioni and fideiussioni garantito expected vatNumber as mandatory data

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in local environment, for this two product the feature is not available
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-4752]: https://pagopa.atlassian.net/browse/SELC-4752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ