### PR TITLE
[SELC-4742] fix: equals2vatNumber checkbox issue

### DIFF
--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -605,10 +605,7 @@ export default function PersonalAndBillingDataSection({
               xs={12}
               pl={3}
               pt={
-                !isForeignInsurance ||
-                (formik.values.hasVatnumber &&
-                  selectedParty?.taxCode !== '' &&
-                  selectedParty?.taxCode)
+                !isForeignInsurance || (formik.values.hasVatnumber && selectedParty?.taxCode !== '')
                   ? 3
                   : 0
               }
@@ -618,8 +615,7 @@ export default function PersonalAndBillingDataSection({
             >
               {!isForeignInsurance &&
                 formik.values.hasVatnumber &&
-                selectedParty?.taxCode !== '' &&
-                selectedParty?.taxCode && (
+                selectedParty?.taxCode !== '' && (
                   <Grid item>
                     <Box display="flex" alignItems="center">
                       <Checkbox

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -746,7 +746,7 @@ const mockedOnboardingRequestData: Array<OnboardingRequestData> = [
   {
     productId: 'prod-pagopa',
     status: 'PENDING',
-    expiringDate: '2024-04-31T01:30:00.000-05:00',
+    expiringDate: '2030-04-31T01:30:00.000-05:00',
   },
   // Expired onboarding request
   {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
[SELC-4742] fix: equals2vatNumber checkbox issue

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Resolved an issue related to equal2vatNumber checkbox that was not showed when taxCode is not defined

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in local environment, all cases are cover as expected
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-4742]: https://pagopa.atlassian.net/browse/SELC-4742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ