### PR TITLE
[SELC-4582] fix: No auto-enabled button for mandatory ipa products for public service managers + added strong unitTests

### DIFF
--- a/src/components/__tests__/StepSearchParty.test.tsx
+++ b/src/components/__tests__/StepSearchParty.test.tsx
@@ -1,7 +1,8 @@
 import { StepSearchParty } from '../steps/StepSearchParty';
 import { mockPartyRegistry, mockedProducts } from '../../lib/__mocks__/mockApiRequests';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { renderComponentWithProviders } from '../../utils/test-utils';
+import { noMandatoryIpaProducts } from '../../utils/constants';
 
 test('Test: Render test', async () => {
   renderComponentWithProviders(
@@ -12,9 +13,7 @@ test('Test: Render test', async () => {
 test('Test: Expected link that allow the public service manager to insert party data also without IPA source', async () => {
   let componentRendered = false;
 
-  const alsoWithoutIpaProducts = mockedProducts.filter(
-    (p) => p.id !== 'prod-interop' && p.id !== 'prod-io' && p.id !== 'prod-io-sign'
-  );
+  const alsoWithoutIpaProducts = mockedProducts.filter((p) => noMandatoryIpaProducts(p.id));
 
   alsoWithoutIpaProducts.forEach((p) => {
     if (!componentRendered) {
@@ -29,15 +28,49 @@ test('Test: Expected link that allow the public service manager to insert party 
       componentRendered = true;
     }
   });
+
   screen.getByText(/Inserisci manualmente i dati del tuo ente./);
+
+  const selectSearchMode = document.getElementById('party-type-select') as HTMLInputElement;
+  fireEvent.mouseDown(selectSearchMode);
+
+  const taxCodeSearch = screen.getByTestId('taxCode');
+  expect(taxCodeSearch).toBeInTheDocument();
+
+  fireEvent.click(taxCodeSearch);
+
+  const continueButton = screen.getByRole('button', { name: 'Continua' });
+  expect(continueButton).toBeDisabled();
+
+  const inputSearch = document.getElementById('Parties') as HTMLInputElement;
+  fireEvent.change(inputSearch, { target: { value: '11111111111' } });
+  screen.getByText('Nessun risultato');
+
+  expect(continueButton).toBeEnabled();
+
+  fireEvent.change(inputSearch, { target: { value: '1111111111' } });
+  expect(continueButton).toBeDisabled();
+
+  fireEvent.mouseDown(selectSearchMode);
+
+  const businessNameSearch = screen.getByTestId('businessName');
+  expect(businessNameSearch).toBeInTheDocument();
+
+  fireEvent.click(businessNameSearch);
+
+  expect(continueButton).toBeDisabled();
+
+  fireEvent.change(inputSearch, { target: { value: 'val' } });
+  expect(continueButton).toBeEnabled();
+
+  fireEvent.change(inputSearch, { target: { value: 'va' } });
+  expect(continueButton).toBeDisabled();
 });
 
 test('Test: The public service manager that onboard one of this products must select party from IPA source', async () => {
   let componentRendered = false;
 
-  const onlyWithIpaProducts = mockedProducts.filter(
-    (p) => p.id === 'prod-interop' || p.id === 'prod-io' || p.id === 'prod-io-sign'
-  );
+  const onlyWithIpaProducts = mockedProducts.filter((p) => !noMandatoryIpaProducts(p.id));
 
   onlyWithIpaProducts.forEach((p) => {
     if (!componentRendered) {
@@ -52,5 +85,38 @@ test('Test: The public service manager that onboard one of this products must se
       componentRendered = true;
     }
   });
+
   screen.getByText(/informazioni sull'indice e su come accreditarsi/);
+
+  const selectSearchMode = document.getElementById('party-type-select') as HTMLInputElement;
+  fireEvent.mouseDown(selectSearchMode);
+
+  const taxCodeSearch = screen.getByTestId('taxCode');
+  expect(taxCodeSearch).toBeInTheDocument();
+
+  fireEvent.click(taxCodeSearch);
+
+  const continueButton = screen.getByRole('button', { name: 'Continua' });
+  expect(continueButton).toBeDisabled();
+
+  const inputSearch = document.getElementById('Parties') as HTMLInputElement;
+  fireEvent.change(inputSearch, { target: { value: '11111111111' } });
+  screen.getByText('Nessun risultato');
+
+  expect(continueButton).toBeDisabled();
+
+  fireEvent.change(inputSearch, { target: { value: '1111111111' } });
+  expect(continueButton).toBeDisabled();
+
+  fireEvent.mouseDown(selectSearchMode);
+
+  const businessNameSearch = screen.getByTestId('businessName');
+  expect(businessNameSearch).toBeInTheDocument();
+
+  fireEvent.click(businessNameSearch);
+
+  expect(continueButton).toBeDisabled();
+
+  fireEvent.change(inputSearch, { target: { value: 'val' } });
+  expect(continueButton).toBeDisabled();
 });

--- a/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
@@ -13,7 +13,7 @@ import { AooData } from '../../../../model/AooData';
 import { InstitutionResource } from '../../../../model/InstitutionResource';
 import { UoData } from '../../../../model/UoModel';
 import { ENV } from '../../../../utils/env';
-import { filterByCategory } from '../../../../utils/constants';
+import { filterByCategory, noMandatoryIpaProducts } from '../../../../utils/constants';
 import AsyncAutocompleteResultsBusinessName from './components/AsyncAutocompleteResultsBusinessName';
 import AsyncAutocompleteResultsCode from './components/AsyncAutocompleteResultsCode';
 import AsyncAutocompleteSearch from './components/AsyncAutocompleteSearch';
@@ -97,7 +97,7 @@ export default function AsyncAutocompleteContainer({
   const showBusinessNameElement = input !== undefined && input.length >= 3;
 
   const disabledButton =
-    institutionType === 'GSP' && product?.id !== 'prod-interop'
+    institutionType === 'GSP' && noMandatoryIpaProducts(product?.id)
       ? isBusinessNameSelected
         ? input.length < 3
         : isTaxCodeSelected

--- a/src/components/steps/StepSearchParty.tsx
+++ b/src/components/steps/StepSearchParty.tsx
@@ -19,7 +19,7 @@ import { LoadingOverlay } from '../LoadingOverlay';
 import { OnboardingStepActions } from '../OnboardingStepActions';
 import { Autocomplete } from '../autocomplete/Autocomplete';
 import { useHistoryState } from '../useHistoryState';
-import { filterByCategory } from '../../utils/constants';
+import { filterByCategory, noMandatoryIpaProducts } from '../../utils/constants';
 
 type Props = {
   subTitle: string | ReactElement;
@@ -89,9 +89,6 @@ export function StepSearchParty({
   const [disabled, setDisabled] = useState<boolean>(false);
 
   const isEnabledProduct2AooUo = product?.id === 'prod-pn';
-
-  const noMandatoryIpaProducts =
-    product?.id !== 'prod-interop' && product?.id !== 'prod-io' && product?.id !== 'prod-io-sign';
 
   const handleSearchTaxCodeFromAooUo = async (query: string) => {
     const searchResponse = await fetchWithLogs(
@@ -414,7 +411,7 @@ export function StepSearchParty({
                 variant="body1"
                 color={theme.palette.text.secondary}
               >
-                {institutionType === 'GSP' && noMandatoryIpaProducts ? (
+                {institutionType === 'GSP' && noMandatoryIpaProducts(product?.id) ? (
                   <Trans
                     i18nKey="onboardingStep1.onboarding.gpsDescription"
                     components={{

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -148,3 +148,6 @@ export const filterByCategory = (institutionType?: string, productId?: string) =
     : institutionType === 'GSP'
     ? 'L37,SAG'
     : 'C17,C16,L10,L19,L13,L2,C10,L20,L21,L22,L15,L1,C13,C5,L40,L11,L39,L46,L8,L34,L7,L35,L45,L47,L6,L12,L24,L28,L42,L36,L44,C8,C3,C7,C14,L16,C11,L33,C12,L43,C2,L38,C1,L5,L4,L31,L18,L17,S01,SA';
+
+export const noMandatoryIpaProducts = (productId?: string) =>
+  productId !== 'prod-interop' && productId !== 'prod-io' && productId !== 'prod-io-sign' && productId !== 'prod-idpay' && !productId?.includes('prod-pn');


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
[SELC-4582] fix: No auto-enabled button for mandatory ipa products for public service managers + added strong unitTests

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fixed auto-enabled button for mandatory ipa products for public service managers and added strong unitTests

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in local environment, dev environment with behaviour tests and with unitTests that cover all the cases required
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-4582]: https://pagopa.atlassian.net/browse/SELC-4582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ