### PR TITLE
[SELC-5040] feat: originId is always filled when available

### DIFF
--- a/src/views/onboarding/Onboarding.tsx
+++ b/src/views/onboarding/Onboarding.tsx
@@ -302,7 +302,7 @@ function OnboardingComponent({ productId }: { productId: string }) {
       taxCodeInvoicing: uoResult?.codiceFiscaleSfe,
       zipCode: aooResult ? aooResult.CAP : uoResult ? uoResult.CAP : party.zipCode,
       geographicTaxonomies: onboardingFormData?.geographicTaxonomies as Array<GeographicTaxonomy>,
-      originId: institutionType === 'AS' ? party.originId : undefined,
+      originId: party.originId,
     });
     forwardWithData(newFormData);
     trackEvent('ONBOARDING_PARTY_SELECTION', {

--- a/src/views/onboarding/__tests__/Onboarding.test.tsx
+++ b/src/views/onboarding/__tests__/Onboarding.test.tsx
@@ -1211,7 +1211,7 @@ const verifySubmit = async (productId = 'prod-idpay') => {
         data: {
           billingData: billingData2billingDataRequest(),
           pspData: undefined,
-          originId: undefined,
+          originId: '991',
           institutionType: 'PA',
           origin: 'IPA',
           users: [


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
[SELC-5040] feat: originId is always filled when available

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The information is no longer valid in the microservice for entities coming from ipa, so it must be sent to the REST submit

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in dev environment, the originId is always filled when available
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5040]: https://pagopa.atlassian.net/browse/SELC-5040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ