### PR TITLE
[SELC-4373] feat: Allowed same taxcode and email with different role for add new user flow

### DIFF
--- a/src/components/ConfirmRegistrationStep0.tsx
+++ b/src/components/ConfirmRegistrationStep0.tsx
@@ -188,9 +188,12 @@ export function ConfirmRegistrationStep0({ forward }: StepperStepComponentProps)
       </Grid>
       <SessionModal
         open={openModal}
-        title={t('onboardingStep1_5.genericError.title')}
+        title={t('stepVerifyOnboarding.genericError.title')}
         message={
-          <Trans i18nKey={'onboardingStep1_5.genericError.description'} components={{ 1: <br /> }}>
+          <Trans
+            i18nKey={'stepVerifyOnboarding.genericError.description'}
+            components={{ 1: <br /> }}
+          >
             {`A causa di un errore del sistema non è possibile completare la procedura.
         <1/>
         Ti chiediamo di riprovare più tardi.`}

--- a/src/components/PlatformUserForm.tsx
+++ b/src/components/PlatformUserForm.tsx
@@ -23,6 +23,7 @@ type PlatformUserFormProps = {
   isExtraDelegate?: boolean;
   buildRemoveDelegateForm?: (idToRemove: string) => (_: React.SyntheticEvent) => void;
   delegateId?: string;
+  addUserFlow: boolean;
 };
 
 type Field = {
@@ -85,11 +86,12 @@ export function validateUser(
   userTempId: keyof UsersObject,
   user: UserOnCreate,
   users: UsersObject,
+  addUserFlow: boolean,
   isAuthUser?: boolean
 ): boolean {
   return (
     fields.filter(({ id }) => !user[id]).map(({ id }) => id).length === 0 && // mandatory fields
-    validateNoMandatory(userTempId, user, users, isAuthUser).length === 0
+    validateNoMandatory(userTempId, user, addUserFlow, users, isAuthUser).length === 0
   );
 }
 
@@ -97,6 +99,7 @@ export function validateUser(
 function validateNoMandatory(
   userTempId: keyof UsersObject,
   user: UserOnCreate,
+  addUserFlow: boolean,
   users?: UsersObject,
   isAuthUser?: boolean
 ): Array<ValidationErrorCode> {
@@ -120,7 +123,11 @@ function validateNoMandatory(
           ? `${id}-regexp`
           : unique &&
             usersArray &&
-            usersArray.findIndex((u) => stringEquals(u[id], user[id], caseSensitive)) > -1
+            usersArray.findIndex(
+              (u) =>
+                (u.role === user.role || !addUserFlow) &&
+                stringEquals(u[id], user[id], caseSensitive)
+            ) > -1
           ? `${id}-unique`
           : id === 'name' &&
             user.name &&
@@ -158,6 +165,7 @@ export function PlatformUserForm({
   isExtraDelegate,
   buildRemoveDelegateForm,
   delegateId,
+  addUserFlow,
 }: PlatformUserFormProps) {
   const { t } = useTranslation();
 
@@ -173,7 +181,7 @@ export function PlatformUserForm({
   };
 
   const errors: Array<ValidationErrorCode> = people[prefix]
-    ? validateNoMandatory(prefix, people[prefix], allPeople, isAuthUser)
+    ? validateNoMandatory(prefix, people[prefix], addUserFlow, allPeople, isAuthUser)
     : [];
 
   const externalErrors: { [errorsUserData: string]: Array<string> } | undefined =
@@ -257,8 +265,7 @@ export function PlatformUserForm({
                   sx={{
                     width: '100%',
                     '& .MuiOutlinedInput-root.MuiInputBase-root': {
-                      fontWeight:
-                      'fontWeightMedium',
+                      fontWeight: 'fontWeightMedium',
                     },
                   }}
                   inputProps={{

--- a/src/components/steps/StepAddManager.tsx
+++ b/src/components/steps/StepAddManager.tsx
@@ -19,6 +19,7 @@ export type UsersError = { [key: string]: { [userField: string]: Array<string> }
 
 type Props = StepperStepComponentProps & {
   externalInstitutionId: string;
+  addUserFlow: boolean;
   readOnly?: boolean;
   subProduct?: Product;
   isTechPartner?: boolean;
@@ -32,6 +33,7 @@ export function StepAddManager({
   back,
   subProduct,
   isTechPartner,
+  addUserFlow,
 }: Props) {
   const { setRequiredLogin } = useContext(UserContext);
   const [_loading, setLoading] = useState(true);
@@ -152,6 +154,7 @@ export function StepAddManager({
             allPeople={people}
             setPeople={setPeople}
             readOnly={readOnly}
+            addUserFlow={addUserFlow}
           />
         </Grid>
       </Grid>
@@ -168,7 +171,8 @@ export function StepAddManager({
               validateUserData(people.LEGAL, 'LEGAL', externalInstitutionId, subProduct);
             },
             label: t('onboardingStep2.confirmLabel'),
-            disabled: objectIsEmpty(people) || !validateUser('LEGAL', people.LEGAL, people),
+            disabled:
+              objectIsEmpty(people) || !validateUser('LEGAL', people.LEGAL, people, addUserFlow),
           }}
         />
       </Grid>

--- a/src/components/steps/StepOnboardingData.tsx
+++ b/src/components/steps/StepOnboardingData.tsx
@@ -33,15 +33,15 @@ const genericError: RequestOutcomeMessage = {
         icon={<IllusError size={60} />}
         variantTitle={'h4'}
         variantDescription={'body1'}
-        title={<Trans i18nKey="onboardingStep1_5.genericError.title" />}
+        title={<Trans i18nKey="stepVerifyOnboarding.genericError.title" />}
         description={
-          <Trans i18nKey="onboardingStep1_5.genericError.description">
+          <Trans i18nKey="stepVerifyOnboarding.genericError.description">
             A causa di un errore del sistema non è possibile completare la procedura.
             <br />
             Ti chiediamo di riprovare più tardi.
           </Trans>
         }
-        buttonLabel={<Trans i18nKey="onboardingStep1_5.genericError.backAction" />}
+        buttonLabel={<Trans i18nKey="stepVerifyOnboarding.genericError.backAction" />}
         onButtonClick={() => window.location.assign(ENV.URL_FE.LANDING)}
       />
       ,

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -68,7 +68,7 @@ export default {
     privacyPolicyLink: 'l’Informativa Privacy e i Termini e Condizioni d’Uso del servizio',
     actionLabel: 'Continua',
   },
-  onboardingStep1_5: {
+  stepVerifyOnboarding: {
     loadingText: 'Stiamo verificando i tuoi dati',
     ptAlreadyOnboarded: {
       title: 'Il Partner è già registrato',

--- a/src/views/OnBoardingSubProduct/OnBoardingSubProduct.tsx
+++ b/src/views/OnBoardingSubProduct/OnBoardingSubProduct.tsx
@@ -312,6 +312,7 @@ function OnBoardingSubProduct() {
         StepAddManager({
           readOnly: false,
           externalInstitutionId,
+          addUserFlow: false,
           product,
           forward: forwardWithManagerData,
           back: () => {

--- a/src/views/UserNotAllowedPage.tsx
+++ b/src/views/UserNotAllowedPage.tsx
@@ -16,13 +16,13 @@ export default function UserNotAllowedPage({ partyName, productTitle }: Props) {
     <EndingPage
       minHeight="52vh"
       icon={<IllusError size={60} />}
-      title={<Trans i18nKey="onboardingStep1_5.userNotAllowedError.title" />}
+      title={<Trans i18nKey="stepVerifyOnboarding.userNotAllowedError.title" />}
       description={
         <Trans
-          i18nKey="onboardingStep1_5.userNotAllowedError.description"
+          i18nKey="stepVerifyOnboarding.userNotAllowedError.description"
           values={{
             productTitle,
-            partyName: partyName ?? t('onboardingStep1_5.userNotAllowedError.noSelectedParty'),
+            partyName: partyName ?? t('stepVerifyOnboarding.userNotAllowedError.noSelectedParty'),
           }}
           components={{
             7: (
@@ -38,7 +38,7 @@ export default function UserNotAllowedPage({ partyName, productTitle }: Props) {
       }
       variantTitle={'h4'}
       variantDescription={'body1'}
-      buttonLabel={<Trans i18nKey="onboardingStep1_5.userNotAllowedError.backToHome" />}
+      buttonLabel={<Trans i18nKey="stepVerifyOnboarding.userNotAllowedError.backToHome" />}
       onButtonClick={() => window.location.assign(ENV.URL_FE.DASHBOARD)}
     />
   );

--- a/src/views/onboarding/Onboarding.tsx
+++ b/src/views/onboarding/Onboarding.tsx
@@ -45,7 +45,7 @@ import { registerUnloadEvent, unregisterUnloadEvent } from '../../utils/unloadEv
 import StepInstitutionType from '../../components/steps/StepInstitutionType';
 import UserNotAllowedPage from '../UserNotAllowedPage';
 import { AdditionalData, AdditionalInformations } from '../../model/AdditionalInformations';
-import { genericError, OnboardingStep1_5 } from './components/OnboardingStep1_5';
+import { genericError, StepVerifyOnboarding } from './components/StepVerifyOnboarding';
 import { OnBoardingProductStepDelegates } from './components/OnBoardingProductStepDelegates';
 import { StepAdditionalInformations } from './components/StepAdditionalInformations';
 
@@ -97,6 +97,7 @@ function OnboardingComponent({ productId }: { productId: string }) {
 
   const [aooSelected, setAooSelected] = useState<AooData>();
   const [uoSelected, setUoSelected] = useState<UoData>();
+  const [addUserFlow, setAddUserFlow] = useState<boolean>(false);
 
   const productAvoidStep =
     selectedProduct?.id === 'prod-pn' || selectedProduct?.id === 'prod-idpay';
@@ -119,6 +120,15 @@ function OnboardingComponent({ productId }: { productId: string }) {
     }
   }, [institutionTypeByUrl]);
 
+  const forwardAfterVerify = (addNewUserFlow: boolean) => {
+    if (addNewUserFlow) {
+      setAddUserFlow(true);
+      setActiveStep(activeStep + 4);
+    } else {
+      forward();
+    }
+  };
+
   const alreadyOnboarded: RequestOutcomeMessage = {
     title: '',
     description: isTechPartner
@@ -129,14 +139,14 @@ function OnboardingComponent({ productId }: { productId: string }) {
               variantTitle="h4"
               variantDescription="body1"
               icon={<IllusError size={60} />}
-              title={<Trans i18nKey="onboardingStep1_5.ptAlreadyOnboarded.title" />}
+              title={<Trans i18nKey="stepVerifyOnboarding.ptAlreadyOnboarded.title" />}
               description={
-                <Trans i18nKey="onboardingStep1_5.ptAlreadyOnboarded.description">
+                <Trans i18nKey="stepVerifyOnboarding.ptAlreadyOnboarded.description">
                   Per operare su un prodotto, chiedi a un Amministratore di <br /> aggiungerti nella
                   sezione Utenti.
                 </Trans>
               }
-              buttonLabel={<Trans i18nKey="onboardingStep1_5.ptAlreadyOnboarded.backAction" />}
+              buttonLabel={<Trans i18nKey="stepVerifyOnboarding.ptAlreadyOnboarded.backAction" />}
               onButtonClick={() => window.location.assign(ENV.URL_FE.LANDING)}
             />
           </Grid>,
@@ -147,10 +157,10 @@ function OnboardingComponent({ productId }: { productId: string }) {
               minHeight="52vh"
               variantTitle={'h4'}
               variantDescription={'body1'}
-              title={<Trans i18nKey="onboardingStep1_5.alreadyOnboarded.title" />}
+              title={<Trans i18nKey="stepVerifyOnboarding.alreadyOnboarded.title" />}
               description={
                 <Trans
-                  i18nKey="onboardingStep1_5.alreadyOnboarded.description"
+                  i18nKey="stepVerifyOnboarding.alreadyOnboarded.description"
                   components={{ 1: <br /> }}
                 >
                   {
@@ -158,7 +168,7 @@ function OnboardingComponent({ productId }: { productId: string }) {
                   }
                 </Trans>
               }
-              buttonLabel={<Trans i18nKey="onboardingStep1_5.alreadyOnboarded.backHome" />}
+              buttonLabel={<Trans i18nKey="stepVerifyOnboarding.alreadyOnboarded.backHome" />}
               onButtonClick={() => window.location.assign(ENV.URL_FE.LANDING)}
             />
           </Grid>,
@@ -684,9 +694,9 @@ function OnboardingComponent({ productId }: { productId: string }) {
     {
       label: 'Verifica ente',
       Component: () =>
-        OnboardingStep1_5({
+        StepVerifyOnboarding({
           product: selectedProduct,
-          forward,
+          forward: forwardAfterVerify,
           externalInstitutionId,
           productId,
           selectedProduct,
@@ -768,6 +778,7 @@ function OnboardingComponent({ productId }: { productId: string }) {
       Component: () =>
         StepAddManager({
           externalInstitutionId,
+          addUserFlow,
           product: selectedProduct,
           isTechPartner,
           forward: (newFormData: Partial<FormData>) => {
@@ -792,6 +803,7 @@ function OnboardingComponent({ productId }: { productId: string }) {
       Component: () =>
         OnBoardingProductStepDelegates({
           externalInstitutionId,
+          addUserFlow,
           product: selectedProduct,
           legal: isTechPartner ? undefined : (formData as any)?.users[0],
           partyName: onboardingFormData?.businessName || '',

--- a/src/views/onboarding/components/OnBoardingProductStepDelegates.tsx
+++ b/src/views/onboarding/components/OnBoardingProductStepDelegates.tsx
@@ -23,6 +23,7 @@ type Props = StepperStepComponentProps & {
   externalInstitutionId: string;
   partyName: string;
   isTechPartner: boolean;
+  addUserFlow: boolean;
 };
 
 export function OnBoardingProductStepDelegates({
@@ -33,6 +34,7 @@ export function OnBoardingProductStepDelegates({
   back,
   partyName,
   isTechPartner,
+  addUserFlow,
 }: Props) {
   const { user, setRequiredLogin } = useContext(UserContext);
   const [_loading, setLoading] = useState(true);
@@ -180,7 +182,9 @@ export function OnBoardingProductStepDelegates({
     objectIsEmpty(people) ||
     Object.keys(people)
       .filter((prefix) => 'LEGAL' !== prefix)
-      .some((prefix) => !validateUser(prefix, people[prefix], allPeople, isAuthUser)) ||
+      .some(
+        (prefix) => !validateUser(prefix, people[prefix], allPeople, addUserFlow, isAuthUser)
+      ) ||
     Object.keys(people).length === 3;
 
   const handleCloseGenericErrorModal = () => {
@@ -256,6 +260,7 @@ export function OnBoardingProductStepDelegates({
             setPeople={setPeople}
             readOnlyFields={isAuthUser ? ['name', 'surname', 'taxCode'] : []}
             isAuthUser={isAuthUser}
+            addUserFlow={addUserFlow}
           />
         </Grid>
         {delegateFormIds.map((id) => (
@@ -270,6 +275,7 @@ export function OnBoardingProductStepDelegates({
               isExtraDelegate={true}
               delegateId={id}
               buildRemoveDelegateForm={buildRemoveDelegateForm}
+              addUserFlow={addUserFlow}
             />
           </Grid>
         ))}
@@ -311,7 +317,10 @@ export function OnBoardingProductStepDelegates({
             objectIsEmpty(people) ||
             Object.keys(people)
               .filter((prefix) => 'LEGAL' !== prefix)
-              .some((prefix) => !validateUser(prefix, people[prefix], allPeople, isAuthUser)),
+              .some(
+                (prefix) =>
+                  !validateUser(prefix, people[prefix], allPeople, addUserFlow, isAuthUser)
+              ),
         }}
       />
 

--- a/src/views/onboarding/components/StepVerifyOnboarding.tsx
+++ b/src/views/onboarding/components/StepVerifyOnboarding.tsx
@@ -33,49 +33,6 @@ type Props = StepperStepComponentProps & {
   uoSelected?: UoData;
 };
 
-const alreadyOnboarded: RequestOutcomeMessage = {
-  title: '',
-  description: [
-    <>
-      <EndingPage
-        minHeight="52vh"
-        variantTitle={'h4'}
-        variantDescription={'body1'}
-        icon={<IllusError size={60} />}
-        title={<Trans i18nKey="onboardingStep1_5.alreadyOnboarded.title" />}
-        description={
-          <Grid container sx={{ display: 'flex', flexDirection: 'column' }}>
-            <Trans
-              i18nKey="onboardingStep1_5.alreadyOnboarded.description"
-              components={{ 1: <br /> }}
-            >
-              {
-                'Per operare sul prodotto, chiedi a un Amministratore di <1/>aggiungerti nella sezione Utenti.'
-              }
-            </Trans>
-            <Grid item>
-              <RolesInformations />
-            </Grid>
-          </Grid>
-        }
-        isParagraphPresent={true}
-        paragraph={
-          <Trans
-            i18nKey="onboardingStep1_5.alreadyOnboarded.addNewAdmin"
-            components={{ 1: <br />, 3: <Link underline="none" onClick={() => {}} /> }}
-          >
-            {
-              'Gli attuali Amministratori non sono più disponibili e hai l’esigenza <1 />di gestire i prodotti? <3>Aggiungi un nuovo Amministratore</3>'
-            }
-          </Trans>
-        }
-        buttonLabel={<Trans i18nKey="onboardingStep1_5.alreadyOnboarded.backHome" />}
-        onButtonClick={() => window.location.assign(ENV.URL_FE.LANDING)}
-      />
-    </>,
-  ],
-};
-
 export const genericError: RequestOutcomeMessage = {
   title: '',
   description: [
@@ -83,9 +40,9 @@ export const genericError: RequestOutcomeMessage = {
       <EndingPage
         minHeight="52vh"
         icon={<IllusError size={60} />}
-        title={<Trans i18nKey="onboardingStep1_5.genericError.title" />}
+        title={<Trans i18nKey="stepVerifyOnboarding.genericError.title" />}
         description={
-          <Trans i18nKey="onboardingStep1_5.genericError.description">
+          <Trans i18nKey="stepVerifyOnboarding.genericError.description">
             A causa di un errore del sistema non è possibile completare la procedura.
             <br />
             Ti chiediamo di riprovare più tardi.
@@ -93,7 +50,7 @@ export const genericError: RequestOutcomeMessage = {
         }
         variantTitle={'h4'}
         variantDescription={'body1'}
-        buttonLabel={<Trans i18nKey="onboardingStep1_5.genericError.backAction" />}
+        buttonLabel={<Trans i18nKey="stepVerifyOnboarding.genericError.backAction" />}
         onButtonClick={() => window.location.assign(ENV.URL_FE.LANDING)}
       />
     </>,
@@ -101,7 +58,7 @@ export const genericError: RequestOutcomeMessage = {
 };
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
-export function OnboardingStep1_5({
+export function StepVerifyOnboarding({
   forward,
   externalInstitutionId,
   productId,
@@ -124,6 +81,54 @@ export function OnboardingStep1_5({
         <UserNotAllowedPage
           partyName={selectedParty?.description}
           productTitle={selectedProduct?.title}
+        />
+      </>,
+    ],
+  };
+
+  const alreadyOnboarded: RequestOutcomeMessage = {
+    title: '',
+    description: [
+      <>
+        <EndingPage
+          minHeight="52vh"
+          variantTitle={'h4'}
+          variantDescription={'body1'}
+          icon={<IllusError size={60} />}
+          title={<Trans i18nKey="stepVerifyOnboarding.alreadyOnboarded.title" />}
+          description={
+            <Grid container sx={{ display: 'flex', flexDirection: 'column' }}>
+              <Trans
+                i18nKey="stepVerifyOnboarding.alreadyOnboarded.description"
+                components={{ 1: <br /> }}
+              >
+                {
+                  'Per operare sul prodotto, chiedi a un Amministratore di <1/>aggiungerti nella sezione Utenti.'
+                }
+              </Trans>
+              <Grid item>
+                <RolesInformations />
+              </Grid>
+            </Grid>
+          }
+          isParagraphPresent={true}
+          paragraph={
+            <Trans
+              i18nKey="stepVerifyOnboarding.alreadyOnboarded.addNewAdmin"
+              components={{
+                1: <br />,
+                3: (
+                  <Link underline="none" sx={{ cursor: 'pointer' }} onClick={() => forward(true)} />
+                ),
+              }}
+            >
+              {
+                'Gli attuali Amministratori non sono più disponibili e hai l’esigenza <1 />di gestire i prodotti? <3>Aggiungi un nuovo Amministratore</3>'
+              }
+            </Trans>
+          }
+          buttonLabel={<Trans i18nKey="stepVerifyOnboarding.alreadyOnboarded.backHome" />}
+          onButtonClick={() => window.location.assign(ENV.URL_FE.LANDING)}
         />
       </>,
     ],
@@ -203,11 +208,11 @@ export function OnboardingStep1_5({
     unregisterUnloadEvent(setOnExit);
   }
   return loading ? (
-    <LoadingOverlay loadingText={t('onboardingStep1_5.loadingText')} />
+    <LoadingOverlay loadingText={t('stepVerifyOnboarding.loadingText')} />
   ) : outcome ? (
     <MessageNoAction {...outcome} />
   ) : (
     <></>
   );
 }
-export default OnboardingStep1_5;
+export default StepVerifyOnboarding;


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
[SELC-4373] feat: Allowed same taxcode and email with different role for add new user flow

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In order to allow the legal representative to be an administrator only for the new user addition flow. The user cannot be admin twice

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in local environment with behaviour tests and unit tests, the legal representative can be an administrator only for the new user addition flow and can't be admin twice
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-4373]: https://pagopa.atlassian.net/browse/SELC-4373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ