### PR TITLE
[SELC-5208] feat: Replaced getProducts with getProductsAdmin + removed product filtering

### DIFF
--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -14,6 +14,7 @@ import {
 import { BillingDataDto } from '../../model/BillingData';
 import { GeographicTaxonomyResource, nationalValue } from '../../model/GeographicTaxonomies';
 import { UoData } from '../../model/UoModel';
+import { addUserFlowProducts } from '../../utils/constants';
 import { AooData } from './../../model/AooData';
 
 const createPartyRegistryEntity = (
@@ -1238,6 +1239,13 @@ export async function mockFetch(
   if (endpoint === 'ONBOARDING_GET_PRODUCTS') {
     return new Promise((resolve) =>
       resolve({ data: mockedProducts, status: 200, statusText: '200' } as AxiosResponse)
+    );
+  }
+
+  if (endpoint === 'ONBOARDING_GET_ALLOWED_ADD_USER_PRODUCTS') {
+    const allowedAddUserProduct = mockedProducts.filter((p) => addUserFlowProducts(p.id));
+    return new Promise((resolve) =>
+      resolve({ data: allowedAddUserProduct, status: 200, statusText: '200' } as AxiosResponse)
     );
   }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -132,6 +132,9 @@ export const API = {
   ONBOARDING_GET_PRODUCTS: {
     URL: ENV.URL_API.ONBOARDING + '/products',
   },
+  ONBOARDING_GET_ALLOWED_ADD_USER_PRODUCTS: {
+    URL: ENV.URL_API.ONBOARDING_V2 + '/v1/products/admin',
+  },
   ONBOARDING_GET_INSTITUTIONS: {
     URL: ENV.URL_API.ONBOARDING_V2 + '/v2/institutions',
   },

--- a/src/views/onboardingRequest/cancel/__tests__/CancelRequestComponent.test.tsx
+++ b/src/views/onboardingRequest/cancel/__tests__/CancelRequestComponent.test.tsx
@@ -111,7 +111,7 @@ test('Test: The jwt exist and the request is correctly retrieved, cancel onboard
 
   // TODO Deprecated
   expect(mockedLocation.assign).toBeCalledWith(ENV.URL_FE.LANDING);
-  expect(fetchWithLogsSpy).toBeCalledTimes(2);
+  expect(fetchWithLogsSpy).toBeCalledTimes(1);
 });
 
 // TODO Review this

--- a/src/views/onboardingUser/OnboardingUser.tsx
+++ b/src/views/onboardingUser/OnboardingUser.tsx
@@ -198,6 +198,7 @@ function OnboardingUserComponent() {
       Component: () =>
         StepSelectProduct({
           forward: forwardWithProduct,
+          back,
           setLoading,
           institutionType,
         }),

--- a/src/views/onboardingUser/__tests__/OnboardingUser.test.tsx
+++ b/src/views/onboardingUser/__tests__/OnboardingUser.test.tsx
@@ -10,6 +10,8 @@ import { MemoryRouter } from 'react-router-dom';
 import OnboardingUser from '../OnboardingUser';
 import { mockPartyRegistry, mockedProducts } from '../../../lib/__mocks__/mockApiRequests';
 
+jest.setTimeout(6000);
+
 const renderComponent = (productId: string) => {
   const Component = () => {
     const [user, setUser] = useState<User | null>(null);

--- a/src/views/onboardingUser/components/StepSelectProduct.tsx
+++ b/src/views/onboardingUser/components/StepSelectProduct.tsx
@@ -37,7 +37,7 @@ export function StepSelectProduct({ forward, setLoading, institutionType }: Prop
     setLoading(true);
     const getProductsRequest = await fetchWithLogs(
       {
-        endpoint: 'ONBOARDING_GET_PRODUCTS',
+        endpoint: 'ONBOARDING_GET_ALLOWED_ADD_USER_PRODUCTS',
       },
       {
         method: 'GET',
@@ -47,15 +47,9 @@ export function StepSelectProduct({ forward, setLoading, institutionType }: Prop
     const outcome = getFetchOutcome(getProductsRequest);
     setLoading(false);
     if (outcome === 'success') {
-      const products = (getProductsRequest as AxiosResponse).data as Array<ProductResource>;
-      const enabledAddUserProducts = products.filter(
-        (p) =>
-          p.id === 'prod-io' ||
-          p.id === 'prod-pagopa' ||
-          p.id === 'prod-interop' ||
-          p.id === 'prod-pn'
-      );
-      setProducts(enabledAddUserProducts);
+      const retrievedProducts = (getProductsRequest as AxiosResponse)
+        .data as Array<ProductResource>;
+      setProducts(retrievedProducts);
     }
   };
 

--- a/types.ts
+++ b/types.ts
@@ -63,7 +63,7 @@ export type RequestOutcomeOptionsJwt = { [key in RequestOutcomeComplete]: Reques
 export type StepperStepComponentProps = {
   product?: Product | null;
   forward?: any;
-  back?: VoidFunction;
+  back?: any;
   updateFormData?: React.Dispatch<React.SetStateAction<any>>;
 };
 


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
[SELC-5208] feat: Replaced getProducts with getProductsAdmin + removed product filtering

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Invoked the new REST dedicated only for the add user flow in order to retrieve only the products allowed to add new user instead of all products

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in dev environment, the API give only the products expected.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5208]: https://pagopa.atlassian.net/browse/SELC-5208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ