### PR TITLE
[SELC-5202] feat: Added isAggregator checkbox only for PA institution types + unit test

### DIFF
--- a/src/components/__tests__/StepSearchParty.test.tsx
+++ b/src/components/__tests__/StepSearchParty.test.tsx
@@ -31,6 +31,9 @@ test('Test: Expected link that allow the public service manager to insert party 
 
   screen.getByText(/Inserisci manualmente i dati del tuo ente./);
 
+  const aggregator = screen.queryByText('Sono un ente aggregatore');
+  expect(aggregator).not.toBeInTheDocument();
+
   const selectSearchMode = document.getElementById('party-type-select') as HTMLInputElement;
   fireEvent.mouseDown(selectSearchMode);
 
@@ -88,6 +91,9 @@ test('Test: The public service manager that onboard one of this products must se
 
   screen.getByText(/informazioni sull'indice e su come accreditarsi/);
 
+  const aggregator = screen.queryByText('Sono un ente aggregatore');
+  expect(aggregator).not.toBeInTheDocument();
+
   const selectSearchMode = document.getElementById('party-type-select') as HTMLInputElement;
   fireEvent.mouseDown(selectSearchMode);
 
@@ -119,4 +125,27 @@ test('Test: The public service manager that onboard one of this products must se
 
   fireEvent.change(inputSearch, { target: { value: 'val' } });
   expect(continueButton).toBeDisabled();
+});
+
+test('Test: Onboarding as PA institution type, expected the aggregator checkbox', async () => {
+  let componentRendered = false;
+
+  mockedProducts.forEach((p) => {
+    if (!componentRendered) {
+      renderComponentWithProviders(
+        <StepSearchParty
+          subTitle={''}
+          externalInstitutionId={mockPartyRegistry.items[0].taxCode}
+          institutionType="PA"
+          product={p}
+        />
+      );
+      componentRendered = true;
+    }
+  });
+
+  screen.getByText(/informazioni sull'indice e su come accreditarsi/);
+
+  const aggregator = screen.queryByText('Sono un ente aggregatore');
+  expect(aggregator).toBeInTheDocument();
 });

--- a/src/components/steps/StepSearchParty.tsx
+++ b/src/components/steps/StepSearchParty.tsx
@@ -1,8 +1,9 @@
-import { Alert, Grid, Link, Typography, useTheme } from '@mui/material';
+import { Alert, FormControlLabel, Grid, Link, Typography, useTheme } from '@mui/material';
 import { Box } from '@mui/system';
 import { AxiosError, AxiosResponse } from 'axios';
 import { ReactElement, useContext, useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
+import Checkbox from '@mui/material/Checkbox';
 import {
   IPACatalogParty,
   InstitutionType,
@@ -311,7 +312,7 @@ export function StepSearchParty({
         </Grid>
       </Grid>
 
-      <Grid container item justifyContent="center" mt={4} mb={4}>
+      <Grid container item sx={{ alignItems: 'center', flexDirection: 'column' }} mt={4} mb={4}>
         {product?.id === 'prod-pn' && (
           <Grid container item justifyContent="center">
             <Grid item display="flex" justifyContent="center" mb={5}>
@@ -390,6 +391,16 @@ export function StepSearchParty({
             institutionType={institutionType}
           />
         </Grid>
+        {institutionType === 'PA' && (
+          <Grid item mt={3}>
+            <FormControlLabel
+              value={false}
+              control={<Checkbox size="small" />}
+              onClick={() => {}}
+              label={t('onboardingStep1.onboarding.aggregator')}
+            />
+          </Grid>
+        )}
       </Grid>
       {institutionType !== 'SA' && institutionType !== 'AS' && (
         <Grid container item justifyContent="center">

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -136,6 +136,7 @@ export default {
       },
       bodyDescription:
         'Inserisci uno dei dati richiesti e cerca dall’Indice della Pubblica <1/> Amministrazione (IPA) l’ente per cui vuoi richiedere l’adesione a <3/><4>{{productTitle}}</4>.',
+      aggregator: 'Sono un ente aggregatore',
       ipaDescription: `Non trovi il tuo ente nell'IPA? <1>In questa pagina</1> trovi maggiori <3/> informazioni sull'indice e su come accreditarsi `,
       selectedInstitution:
         'Prosegui con l’adesione a <1>{{productName}}</1> per l’ente selezionato',


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
[SELC-5202] feat: Added isAggregator checkbox only for PA institution types + unit test

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Manage aggregator onboardings, added this checkbox that allow the party to self declare as aggregator

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in local environment with unit test and executing the client, the checkbox appears only for PA for all products as expected
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5202]: https://pagopa.atlassian.net/browse/SELC-5202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ