### PR TITLE
[SELC-5209] feat: Added "(facoltativo)" in the email address field for all products except "Firma con IO"

### DIFF
--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -856,11 +856,11 @@ export default function PersonalAndBillingDataSection({
                     'businessRegisterPlace',
                     isContractingAuthority
                       ? t(
-                          'onboardingFormData.billingDataSection.informationCompanies.requiredCommercialRegisterNumber'
-                        )
+                        'onboardingFormData.billingDataSection.informationCompanies.requiredCommercialRegisterNumber'
+                      )
                       : t(
-                          'onboardingFormData.billingDataSection.informationCompanies.commercialRegisterNumber'
-                        ),
+                        'onboardingFormData.billingDataSection.informationCompanies.commercialRegisterNumber'
+                      ),
                     600,
                     theme.palette.text.primary
                   )}
@@ -886,11 +886,11 @@ export default function PersonalAndBillingDataSection({
                     'shareCapital',
                     isContractingAuthority
                       ? t(
-                          'onboardingFormData.billingDataSection.informationCompanies.requiredShareCapital'
-                        )
+                        'onboardingFormData.billingDataSection.informationCompanies.requiredShareCapital'
+                      )
                       : t(
-                          'onboardingFormData.billingDataSection.informationCompanies.shareCapital'
-                        ),
+                        'onboardingFormData.billingDataSection.informationCompanies.shareCapital'
+                      ),
                     600,
                     theme.palette.text.primary
                   )}
@@ -968,9 +968,11 @@ export default function PersonalAndBillingDataSection({
               <CustomTextField
                 {...baseTextFieldProps(
                   'supportEmail',
-                  t('onboardingFormData.billingDataSection.assistanceContact.supportEmail'),
+                  t(productId === "prod-io"
+                    ? 'onboardingFormData.billingDataSection.assistanceContact.supportEmail'
+                    : 'onboardingFormData.billingDataSection.assistanceContact.supportEmailOptional'),
                   600,
-                  theme.palette.text.primary
+                  theme.palette.text.primary,
                 )}
               />
               {/* descrizione indirizzo mail di supporto */}

--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -968,7 +968,7 @@ export default function PersonalAndBillingDataSection({
               <CustomTextField
                 {...baseTextFieldProps(
                   'supportEmail',
-                  t(productId === "prod-io"
+                  t(productId === "prod-io-sign"
                     ? 'onboardingFormData.billingDataSection.assistanceContact.supportEmail'
                     : 'onboardingFormData.billingDataSection.assistanceContact.supportEmailOptional'),
                   600,

--- a/src/components/onboardingFormData/__tests__/PersonalAndBillingDataSection.test.tsx
+++ b/src/components/onboardingFormData/__tests__/PersonalAndBillingDataSection.test.tsx
@@ -87,12 +87,13 @@ test('Test: Rendered PersonalAndBillingDataSection component with all possible b
   let party;
   let aooSelected;
   let uoSelected;
+  let productId;
 
   // TODO Temporary excluded the PSP institutionType
   mockedProducts.forEach((product) => {
     institutionTypes.forEach((institutionType) => {
       if (!componentRendered) {
-        const productId = product.id;
+        productId = product.id;
 
         switch (productId) {
           case 'prod-pn':
@@ -153,6 +154,7 @@ test('Test: Rendered PersonalAndBillingDataSection component with all possible b
             aooSelected={aooSelected}
             uoSelected={uoSelected}
             isDisabled={isDisabled}
+            setInvalidTaxCodeInvoicing={jest.fn()}
           />
         );
 
@@ -195,6 +197,7 @@ test('Test: Rendered PersonalAndBillingDataSection component with all possible b
     const sdiCode = screen.queryByText('Codice SDI');
     const shareCapital = screen.queryByText('Capitale sociale (facoltativo)');
     const visibleCitizenMail = screen.queryByText('Indirizzo email visibile ai cittadini');
+    const visibleCitizenMailOptional = screen.queryByText('Indirizzo email visibile ai cittadini (facoltativo)');
 
     if (aooSelected) {
       expect(businessName).not.toBeInTheDocument();
@@ -254,7 +257,7 @@ test('Test: Rendered PersonalAndBillingDataSection component with all possible b
     if (institutionAvoidGeotax) {
       expect(visibleCitizenMail).not.toBeInTheDocument();
     } else {
-      expect(visibleCitizenMail).toBeInTheDocument();
+      expect(productId === "prod-io" ? visibleCitizenMail : visibleCitizenMailOptional).toBeInTheDocument();
     }
 
     const isTaxCodeEquals2PIVA = document.getElementById('taxCodeEquals2VatNumber');

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -637,6 +637,7 @@ export default {
       },
       assistanceContact: {
         supportEmail: 'Indirizzo email visibile ai cittadini',
+        supportEmailOptional: "Indirizzo email visibile ai cittadini (facoltativo)",
         supportEmailDescriprion:
           'È il contatto che i cittadini visualizzano per richiedere assistenza all’ente',
       },


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Added text "(facoltativo)" in the email address field label for all products except for "Firma con IO"


#### Motivation and Context

For the Product "Firma con IO" the email address field is required, for all the other product it's not

#### How Has This Been Tested?

local env

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.