### PR TITLE
[SELC-5203] feat: Added modal before forward when party is an aggregator

### DIFF
--- a/src/components/steps/StepSearchParty.tsx
+++ b/src/components/steps/StepSearchParty.tsx
@@ -4,6 +4,7 @@ import { AxiosError, AxiosResponse } from 'axios';
 import { ReactElement, useContext, useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import Checkbox from '@mui/material/Checkbox';
+import { SessionModal } from '@pagopa/selfcare-common-frontend';
 import {
   IPACatalogParty,
   InstitutionType,
@@ -88,6 +89,8 @@ export function StepSearchParty({
   );
   const [dataFromAooUo, setDataFromAooUo] = useState<IPACatalogParty | null>();
   const [disabled, setDisabled] = useState<boolean>(false);
+  const [isAggregator, setIsAggregator] = useState<boolean>(false);
+  const [open, setOpen] = useState<boolean>(false);
 
   const isEnabledProduct2AooUo = product?.id === 'prod-pn';
 
@@ -396,7 +399,7 @@ export function StepSearchParty({
             <FormControlLabel
               value={false}
               control={<Checkbox size="small" />}
-              onClick={() => {}}
+              onClick={() => setIsAggregator(true)}
               label={t('onboardingStep1.onboarding.aggregator')}
             />
           </Grid>
@@ -475,12 +478,35 @@ export function StepSearchParty({
               : undefined
           }
           forward={{
-            action: onForwardAction,
+            action: () => {
+              if (isAggregator) {
+                setOpen(true);
+              } else {
+                onForwardAction();
+              }
+            },
             label: t('onboardingStep1.onboarding.onboardingStepActions.confirmAction'),
             disabled,
           }}
         />
       </Grid>
+      <SessionModal
+        open={open}
+        title={t('onboardingStep1.onboarding.aggregatorModal.title')}
+        message={
+          <Trans
+            i18nKey={'onboardingStep1.onboarding.aggregatorModal.message'}
+            components={{ 1: <br /> }}
+            values={{ partyName: selected?.description }}
+          >
+            {`Stai richiedendo l’adesione come ente aggregatore per {{partyName}}.<1 />Per completare l’adesione, dovrai indicare gli enti da aggregare.`}
+          </Trans>
+        }
+        onCloseLabel={t('onboardingStep1.onboarding.aggregatorModal.back')}
+        onConfirmLabel={t('onboardingStep1.onboarding.aggregatorModal.forward')}
+        handleClose={() => setOpen(false)}
+        onConfirm={onForwardAction}
+      />
     </Grid>
   );
 }

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -668,6 +668,7 @@ const mockedOnboardingData: Array<InstitutionOnboardingInfoResource> = [
 const mockedOnboardedParties: Array<OnboardedParty> = [
   {
     id: '1',
+    description: 'onboardedParty1',
     institutionType: 'PA',
     origin: 'IPA',
     originId: 'sdsdee',
@@ -676,6 +677,7 @@ const mockedOnboardedParties: Array<OnboardedParty> = [
   },
   {
     id: '1',
+    description: 'onboardedParty2',
     institutionType: 'PA',
     origin: 'IPA',
     originId: 'sdsdee',

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -135,6 +135,12 @@ export default {
       bodyDescription:
         'Inserisci uno dei dati richiesti e cerca dall’Indice della Pubblica <1/> Amministrazione (IPA) l’ente per cui vuoi richiedere l’adesione a <3/><4>{{productTitle}}</4>.',
       aggregator: 'Sono un ente aggregatore',
+      aggregatorModal: {
+        title: 'Ente aggregatore',
+        message: `Stai richiedendo l’adesione come ente aggregatore per {{partyName}}.<1 />Per completare l’adesione, dovrai indicare gli enti da aggregare.`,
+        back: 'Indietro',
+        forward: 'Continua',
+      },
       ipaDescription: `Non trovi il tuo ente nell'IPA? <1>In questa pagina</1> trovi maggiori <3/> informazioni sull'indice e su come accreditarsi `,
       selectedInstitution:
         'Prosegui con l’adesione a <1>{{productName}}</1> per l’ente selezionato',

--- a/src/model/OnboardedParty.ts
+++ b/src/model/OnboardedParty.ts
@@ -1,8 +1,10 @@
 export type OnboardedParty = {
   id: string;
+  description: string;
   productId: string;
   institutionType: string;
   taxCode: string;
+  parentDescription?: string;
   origin?: string;
   originId?: string;
   subunitCode?: string;

--- a/src/model/OnboardingFormData.ts
+++ b/src/model/OnboardingFormData.ts
@@ -34,4 +34,5 @@ export type OnboardingFormData = {
   uoUniqueCode?: string;
   isForeignInsurance?: boolean;
   hasVatnumber?: boolean;
+  origin?: string;
 };

--- a/src/utils/selected2OnboardingData.ts
+++ b/src/utils/selected2OnboardingData.ts
@@ -26,4 +26,5 @@ export const selected2OnboardingData = (selectedParty: any): OnboardingFormData 
   zipCode: selectedParty?.CAP ? selectedParty.CAP : selectedParty?.zipCode,
   geographicTaxonomies: [],
   originId: selectedParty?.originId,
+  origin: selectedParty?.origin,
 });

--- a/src/views/onboardingProduct/OnboardingProduct.tsx
+++ b/src/views/onboardingProduct/OnboardingProduct.tsx
@@ -353,6 +353,7 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
       taxCodeInvoicing: uoResult?.codiceFiscaleSfe,
       zipCode: aooResult ? aooResult.CAP : uoResult ? uoResult.CAP : party.zipCode,
       geographicTaxonomies: onboardingFormData?.geographicTaxonomies as Array<GeographicTaxonomy>,
+      origin: party.origin,
       originId: party.originId,
     });
     forwardWithData(newFormData);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
[SELC-5203] feat: Added modal before forward when party is an aggregator

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In order to notify the party that is self-declaring itself as an aggregator before proceeding

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in local environment, the popup appears correctly only when the aggregator checkbox is checked
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5203]: https://pagopa.atlassian.net/browse/SELC-5203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ