### PR TITLE
[SELC-5240] feat: originId filled with subunitCode + added partyLogo and parentDescription in the selected party if present

### DIFF
--- a/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
@@ -4,6 +4,7 @@ import { AxiosError, AxiosResponse } from 'axios';
 import debounce from 'lodash/debounce';
 import { Dispatch, SetStateAction, useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import OnboardingPartyIcon from '../../../../assets/onboarding_party_icon.svg';
 import {
   ANACParty,
   ApiEndpointKey,
@@ -11,7 +12,6 @@ import {
   InstitutionType,
   Product,
 } from '../../../../../types';
-import { ReactComponent as PartyIcon } from '../../../../assets/onboarding_party_icon.svg';
 import { fetchWithLogs } from '../../../../lib/api-utils';
 import { UserContext } from '../../../../lib/context';
 import { getFetchOutcome } from '../../../../lib/error-utils';
@@ -19,7 +19,11 @@ import { AooData } from '../../../../model/AooData';
 import { InstitutionResource } from '../../../../model/InstitutionResource';
 import { UoData } from '../../../../model/UoModel';
 import { ENV } from '../../../../utils/env';
-import { filterByCategory, noMandatoryIpaProducts } from '../../../../utils/constants';
+import {
+  buildUrlLogo,
+  filterByCategory,
+  noMandatoryIpaProducts,
+} from '../../../../utils/constants';
 import AsyncAutocompleteResultsBusinessName from './components/AsyncAutocompleteResultsBusinessName';
 import AsyncAutocompleteResultsCode from './components/AsyncAutocompleteResultsCode';
 import AsyncAutocompleteSearch from './components/AsyncAutocompleteSearch';
@@ -97,6 +101,9 @@ export default function AsyncAutocompleteContainer({
   const { setRequiredLogin } = useContext(UserContext);
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
+  const [partyLogo, setPartyLogo] = useState<string>(
+    selected ? buildUrlLogo(selected.id) : OnboardingPartyIcon
+  );
 
   const getOptionKey: (option: any) => string =
     optionKey !== undefined ? (o) => o[optionKey] : (o) => o.label ?? o;
@@ -124,6 +131,15 @@ export default function AsyncAutocompleteContainer({
       setDisabled(!selected);
     }
   }, [input, selected]);
+
+  useEffect(() => {
+    if (selected) {
+      const logoUrl = buildUrlLogo(selected.id);
+      setPartyLogo(logoUrl);
+    } else {
+      setPartyLogo(OnboardingPartyIcon);
+    }
+  }, [selected]);
 
   const handleSearchByName = async (
     query: string,
@@ -403,7 +419,11 @@ export default function AsyncAutocompleteContainer({
       >
         {selected && (
           <Box display="flex" alignItems="center">
-            <PartyIcon width={50} />
+            <img
+              style={{ height: 50, width: 50 }}
+              onError={() => setPartyLogo(OnboardingPartyIcon)}
+              src={partyLogo}
+            />
           </Box>
         )}
 

--- a/src/components/autocomplete/components/asyncAutocomplete/components/AsyncAutocompleteResultsCode.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/components/AsyncAutocompleteResultsCode.tsx
@@ -88,9 +88,9 @@ export default function AsyncAutocompleteResultsCode({
             }
             partyRole={
               !isTaxCodeSelected && aooResult
-                ? aooResult.denominazioneEnte
+                ? aooResult.denominazioneEnte || aooResult.parentDescription
                 : uoResult
-                ? uoResult?.denominazioneEnte
+                ? uoResult?.denominazioneEnte || uoResult.parentDescription
                 : ''
             }
             image={' '}

--- a/src/components/autocomplete/components/asyncAutocomplete/components/AsyncAutocompleteResultsCode.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/components/AsyncAutocompleteResultsCode.tsx
@@ -84,7 +84,7 @@ export default function AsyncAutocompleteResultsCode({
                 ? aooResult?.denominazioneAoo.toLocaleLowerCase()
                 : isUoCodeSelected && uoResult?.descrizioneUo
                 ? uoResult?.descrizioneUo.toLocaleLowerCase()
-                : visibleCode.description
+                : visibleCode?.description
             }
             partyRole={
               !isTaxCodeSelected && aooResult

--- a/src/components/autocomplete/components/asyncAutocomplete/components/AsyncAutocompleteSearch.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/components/AsyncAutocompleteSearch.tsx
@@ -113,14 +113,17 @@ export default function AsyncAutocompleteSearch({
         id="Parties"
         sx={{
           width: '100%',
-          mx: selected ? 1 : 4,
+          mx: selected ? '6px' : 4,
+          ml: selected ? '12px' : 4,
           '& input#Parties': { display: selected && 'none !important' },
         }}
         onChange={handleChange}
         value={!selected ? valueSelected : ''}
         label={
           !selected
-            ? isAooCodeSelected
+            ? isBusinessNameSelected || isTaxCodeSelected
+              ? t('asyncAutocomplete.searchLabel')
+              : isAooCodeSelected
               ? t('asyncAutocomplete.aooLabel')
               : isUoCodeSelected
               ? t('asyncAutocomplete.uoLabel')
@@ -132,7 +135,7 @@ export default function AsyncAutocompleteSearch({
           // maxLength: isTaxCodeSelected ? '11' : undefined,
           style: {
             fontStyle: 'normal',
-            fontWeight: '700',
+            fontWeight: '600',
             fontSize: '16px',
             lineHeight: '24px',
             color: theme.palette.text.primary,

--- a/src/components/autocomplete/components/asyncAutocomplete/components/AsyncAutocompleteSearch.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/components/AsyncAutocompleteSearch.tsx
@@ -166,7 +166,7 @@ export default function AsyncAutocompleteSearch({
                     }),
                   }}
                 >
-                  {selected.denominazioneEnte}
+                  {selected.denominazioneEnte ?? selected.parentDescription}
                 </Typography>
               )}
             </Box>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -221,11 +221,7 @@ export const institutionType4Product = (productId: string | undefined) => {
           (ENV.PT.SHOW_PT ? it.labelKey === 'pt' : '')
       );
     case 'prod-io-sign':
-      return institutionTypes.filter(
-        (it) =>
-          it.labelKey === 'pa' ||
-          it.labelKey === 'gsp'
-      );
+      return institutionTypes.filter((it) => it.labelKey === 'pa' || it.labelKey === 'gsp');
     default:
       return institutionTypes.filter(
         (it) => it.labelKey === 'pa' || it.labelKey === 'gsp' || it.labelKey === 'scp'
@@ -250,3 +246,6 @@ export const description4InstitutionType = (institutionType: InstitutionType) =>
       return '';
   }
 };
+
+export const buildUrlLogo = (partyId: string) =>
+  `${ENV.URL_INSTITUTION_LOGO.PREFIX}${partyId}${ENV.URL_INSTITUTION_LOGO.SUFFIX}`;

--- a/src/views/onboardingPremium/components/SubProductStepVerifyInputs.tsx
+++ b/src/views/onboardingPremium/components/SubProductStepVerifyInputs.tsx
@@ -7,7 +7,7 @@ import { fetchWithLogs } from '../../../lib/api-utils';
 import { getFetchOutcome } from '../../../lib/error-utils';
 import NoProductPage from '../../NoProductPage';
 import { unregisterUnloadEvent } from '../../../utils/unloadEvent-utils';
-import { ENV } from '../../../utils/env';
+import { buildUrlLogo } from '../../../utils/constants';
 
 type Props = StepperStepComponentProps & {
   requestId: string;
@@ -38,9 +38,6 @@ const checkProduct = async (
     setter(null);
   }
 };
-
-const buildUrlLog = (partyId: string) =>
-  `${ENV.URL_INSTITUTION_LOGO.PREFIX}${partyId}${ENV.URL_INSTITUTION_LOGO.SUFFIX}`;
 
 const handleSearchUserParties = async (
   setParties: (parties: Array<SelfcareParty>) => void,
@@ -81,14 +78,14 @@ const handleSearchUserParties = async (
       setParties(
         partiesWithBaseProduct.map((p) => ({
           ...p,
-          urlLogo: buildUrlLog(p.id),
+          urlLogo: buildUrlLogo(p.id),
         }))
       );
     } else {
       setParties(
         partiesWithoutPremium.map((p) => ({
           ...p,
-          urlLogo: buildUrlLog(p.id),
+          urlLogo: buildUrlLogo(p.id),
         }))
       );
     }

--- a/src/views/onboardingProduct/OnboardingProduct.tsx
+++ b/src/views/onboardingProduct/OnboardingProduct.tsx
@@ -513,7 +513,11 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
               ? companyInformationsDto2pspDataRequest(onboardingFormData as OnboardingFormData)
               : undefined,
           institutionType,
-          originId: onboardingFormData?.originId,
+          originId: aooSelected
+            ? aooSelected.codiceUniAoo
+            : uoSelected
+            ? uoSelected.codiceUniUo
+            : onboardingFormData?.originId,
           geographicTaxonomies: ENV.GEOTAXONOMY.SHOW_GEOTAXONOMY
             ? onboardingFormData?.geographicTaxonomies?.map((gt) =>
                 onboardedInstitutionInfo2geographicTaxonomy(gt)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
[SELC-5240] feat: originId filled with subunitCode + added partyLogo and parentDescription in the selected party if present

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In order to provide the originId as the subunitCode instead of the ipa code of EC and develop some improvements

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in dev environment, the parentDescription and the partyLogo are showed if present (in the case of partyLogo, if not present a custom logo, the default logo is showed). Done some onboarding and, now, the originId is enhanced with the subunit code in the case of AOO or UO onboarding
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5240]: https://pagopa.atlassian.net/browse/SELC-5240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ