### PR TITLE
[SELC-5172] feat: Allow to access to "Società a controllo pubblico" for interoperability

### DIFF
--- a/src/components/__tests__/StepInstitutionType.test.tsx
+++ b/src/components/__tests__/StepInstitutionType.test.tsx
@@ -41,7 +41,7 @@ test('Test: The correct institution types with the expected descriptions, can be
           expect(institutionTypeValues).toStrictEqual(['PA']);
           break;
         case 'prod-interop':
-          expect(institutionTypeValues).toStrictEqual(['PA', 'GSP', 'SA', 'AS']);
+          expect(institutionTypeValues).toStrictEqual(['PA', 'GSP', 'SCP', 'SA', 'AS',]);
           break;
         default:
           expect(institutionTypeValues).toStrictEqual(['PA', 'GSP', 'SCP']);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -205,6 +205,7 @@ export const institutionType4Product = (productId: string | undefined) => {
           it.labelKey === 'pa' ||
           it.labelKey === 'gsp' ||
           it.labelKey === 'sa' ||
+          it.labelKey === 'scp' ||
           it.labelKey === 'as'
       );
     case 'prod-pn':


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-5172] feat: Allow to access to "Società a controllo pubblico" for interoperability

#### Motivation and Context

Allow to access to "Società a controllo pubblico" for interoperability product

#### How Has This Been Tested?

Checked if the "Società a controllo pubblico" choice is prensent  in first step page

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5172]: https://pagopa.atlassian.net/browse/SELC-5172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ