### PR TITLE
feat: Aggregates feature available only for prod-io + added aggregates list on submit

### DIFF
--- a/src/components/__tests__/StepSearchParty.test.tsx
+++ b/src/components/__tests__/StepSearchParty.test.tsx
@@ -129,6 +129,7 @@ test('Test: The public service manager that onboard one of this products must se
 
 test('Test: Onboarding as PA institution type, expected the aggregator checkbox', async () => {
   let componentRendered = false;
+  let product = '';
 
   mockedProducts.forEach((p) => {
     if (!componentRendered) {
@@ -141,11 +142,18 @@ test('Test: Onboarding as PA institution type, expected the aggregator checkbox'
         />
       );
       componentRendered = true;
+
+      product = p.id;
     }
   });
 
-  screen.getByText(/informazioni sull'indice e su come accreditarsi/);
-
   const aggregator = screen.queryByText('Sono un ente aggregatore');
-  expect(aggregator).toBeInTheDocument();
+
+  if (product === 'prod-io') {
+    expect(aggregator).toBeInTheDocument();
+  } else {
+    expect(aggregator).not.toBeInTheDocument();
+  }
+
+  screen.getByText(/informazioni sull'indice e su come accreditarsi/);
 });

--- a/src/components/steps/StepSearchParty.tsx
+++ b/src/components/steps/StepSearchParty.tsx
@@ -401,9 +401,7 @@ export function StepSearchParty({
           product?.id === 'prod-io' && (
             <Grid item mt={3}>
               <FormControlLabel
-                value={false}
-                control={<Checkbox size="small" />}
-                onClick={() => setIsAggregator(true)}
+                control={<Checkbox size="small" onChange={() => setIsAggregator(!isAggregator)} />}
                 label={t('onboardingStep1.onboarding.aggregator')}
               />
             </Grid>

--- a/src/components/steps/StepSearchParty.tsx
+++ b/src/components/steps/StepSearchParty.tsx
@@ -396,16 +396,18 @@ export function StepSearchParty({
             institutionType={institutionType}
           />
         </Grid>
-        {ENV.AGGREGATOR.SHOW_AGGREGATOR && institutionType === 'PA' && (
-          <Grid item mt={3}>
-            <FormControlLabel
-              value={false}
-              control={<Checkbox size="small" />}
-              onClick={() => setIsAggregator(true)}
-              label={t('onboardingStep1.onboarding.aggregator')}
-            />
-          </Grid>
-        )}
+        {ENV.AGGREGATOR.SHOW_AGGREGATOR &&
+          institutionType === 'PA' &&
+          product?.id === 'prod-io' && (
+            <Grid item mt={3}>
+              <FormControlLabel
+                value={false}
+                control={<Checkbox size="small" />}
+                onClick={() => setIsAggregator(true)}
+                label={t('onboardingStep1.onboarding.aggregator')}
+              />
+            </Grid>
+          )}
       </Grid>
       {institutionType !== 'SA' && institutionType !== 'AS' && (
         <Grid container item justifyContent="center">

--- a/src/model/AggregateInstitution.ts
+++ b/src/model/AggregateInstitution.ts
@@ -1,0 +1,13 @@
+import { GeographicTaxonomy } from './GeographicTaxonomies';
+
+export type AggregateInstitution = {
+  taxCode: string;
+  description: string;
+  address?: string;
+  geographicTaxonomies?: Array<GeographicTaxonomy>;
+  origin?: string;
+  originId?: string;
+  subunitCode?: string;
+  subunitType?: string;
+  zipCode?: string;
+};

--- a/src/views/onboardingProduct/OnboardingProduct.tsx
+++ b/src/views/onboardingProduct/OnboardingProduct.tsx
@@ -848,6 +848,7 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
       Component: () =>
         StepUploadAggregates({
           productName: selectedProduct?.title,
+          institutionType,
           loading,
           setLoading,
           setOutcome,

--- a/src/views/onboardingProduct/OnboardingProduct.tsx
+++ b/src/views/onboardingProduct/OnboardingProduct.tsx
@@ -47,6 +47,7 @@ import StepInstitutionType from '../../components/steps/StepInstitutionType';
 import UserNotAllowedPage from '../UserNotAllowedPage';
 import { AdditionalData, AdditionalInformations } from '../../model/AdditionalInformations';
 import AlreadyOnboarded from '../AlreadyOnboarded';
+import { AggregateInstitution } from '../../model/AggregateInstitution';
 import { genericError, StepVerifyOnboarding } from './components/StepVerifyOnboarding';
 import { StepAddAdmin } from './components/StepAddAdmin';
 import { StepAdditionalInformations } from './components/StepAdditionalInformations';
@@ -97,6 +98,7 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
   const { t } = useTranslation();
   const [onExitAction, setOnExitAction] = useState<(() => void) | undefined>();
   const [selectedParty, setSelectedParty] = useState<Party>();
+  const [aggregates, setAggregates] = useState<Array<AggregateInstitution>>();
 
   const [aooSelected, setAooSelected] = useState<AooData>();
   const [uoSelected, setUoSelected] = useState<UoData>();
@@ -548,6 +550,7 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
           isAggregator: onboardingFormData?.isAggregator
             ? onboardingFormData?.isAggregator
             : undefined,
+          aggregates,
         },
       },
       () => setRequiredLogin(true)
@@ -850,6 +853,7 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
           productName: selectedProduct?.title,
           institutionType,
           loading,
+          setAggregates,
           setLoading,
           setOutcome,
           forward: onSubmit,

--- a/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
+++ b/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
@@ -1229,6 +1229,7 @@ const verifySubmit = async (productId = 'prod-idpay') => {
           subunitType: undefined,
           taxCode: 'AAAAAA44D55F456K',
           companyInformations: undefined,
+          aggregates: undefined,
         },
         method: 'POST',
       },

--- a/src/views/onboardingProduct/components/StepUploadAggregates.tsx
+++ b/src/views/onboardingProduct/components/StepUploadAggregates.tsx
@@ -13,12 +13,14 @@ import { RowError } from '../../../model/RowError';
 import { fetchWithLogs } from '../../../lib/api-utils';
 import { getFetchOutcome } from '../../../lib/error-utils';
 import { UserContext } from '../../../lib/context';
+import { AggregateInstitution } from '../../../model/AggregateInstitution';
 import { genericError } from './StepVerifyOnboarding';
 
 type Props = {
   loading: boolean;
   setLoading: React.Dispatch<React.SetStateAction<boolean>>;
   setOutcome: React.Dispatch<React.SetStateAction<RequestOutcomeMessage | null | undefined>>;
+  setAggregates: React.Dispatch<React.SetStateAction<Array<AggregateInstitution> | undefined>>;
   productName?: string;
   institutionType?: InstitutionType;
 } & StepperStepComponentProps;
@@ -27,6 +29,7 @@ export function StepUploadAggregates({
   loading,
   setLoading,
   setOutcome,
+  setAggregates,
   productName,
   institutionType,
   forward,
@@ -111,15 +114,17 @@ export function StepUploadAggregates({
 
     if (result === 'success') {
       const errors = (verifyAggregates as AxiosResponse).data.errors as Array<RowError>;
+      const aggregatesList = (verifyAggregates as AxiosResponse).data
+        .aggregates as Array<AggregateInstitution>;
       parseJson2Csv(errors);
 
       if (errors.length === 0) {
+        setAggregates(aggregatesList);
         setDisabled(false);
         forward();
       } else {
         setDisabled(true);
         setFoundErrors(errors);
-        // TODO Parsing json errors to csv will be developed with SELC-5207
       }
     } else {
       setOutcome(genericError);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
feat: Aggregates feature available only for prod-io + added aggregates list on submit

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Persist the aggregates list by pass the list on the onboarding product submit rest api + party self declare as aggregator available only for App IO product.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in dev environment, the list of aggregates and the boolean too are passed correctly if present (in case of party different from PA institutionType and that try to onboard a product different to prod-io, the information are not passed).
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.