### PR TITLE
[SELC-5173] feat: API invocation for private body search via CF

### DIFF
--- a/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
@@ -389,7 +389,7 @@ export default function AsyncAutocompleteContainer({
         } else {
           const endpoint = addUser
             ? 'ONBOARDING_GET_INSTITUTIONS'
-            : product?.id === 'prod-interop'
+            : product?.id === 'prod-interop' && institutionType === 'SCP'
             ? 'ONBOARDING_GET_PARTY_BY_CF_FROM_INFOCAMERE'
             : 'ONBOARDING_GET_PARTY_FROM_CF';
           void handleSearchByTaxCode(

--- a/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
@@ -346,7 +346,6 @@ export default function AsyncAutocompleteContainer({
     // eslint-disable-next-line sonarjs/cognitive-complexity
   ) => {
     const typedInput = event.target.value as string;
-
     const params = {
       productId: selectedProduct?.id,
       taxCode: isTaxCodeSelected ? typedInput : undefined,
@@ -388,8 +387,19 @@ export default function AsyncAutocompleteContainer({
 
           void contractingInsuranceFromTaxId(addUser, endpoint, params, value);
         } else {
-          const endpoint = addUser ? 'ONBOARDING_GET_INSTITUTIONS' : 'ONBOARDING_GET_PARTY_FROM_CF';
-          void handleSearchByTaxCode(addUser, endpoint, params, value);
+          const endpoint = addUser
+            ? 'ONBOARDING_GET_INSTITUTIONS'
+            : product?.id === 'prod-interop'
+            ? 'ONBOARDING_GET_PARTY_BY_CF_FROM_INFOCAMERE'
+            : 'ONBOARDING_GET_PARTY_FROM_CF';
+          void handleSearchByTaxCode(
+            addUser,
+            endpoint,
+            product?.id === 'prod-interop' && institutionType === 'SCP'
+              ? { ...params, taxCode: undefined }
+              : params,
+            value
+          );
         }
       } else if (isAooCodeSelected && !isUoCodeSelected && value.length === 7) {
         const endpoint = addUser ? 'ONBOARDING_GET_INSTITUTIONS' : 'ONBOARDING_GET_AOO_CODE_INFO';

--- a/src/components/autocomplete/components/asyncAutocomplete/components/AsyncAutocompleteResultsCode.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/components/AsyncAutocompleteResultsCode.tsx
@@ -84,7 +84,7 @@ export default function AsyncAutocompleteResultsCode({
                 ? aooResult?.denominazioneAoo.toLocaleLowerCase()
                 : isUoCodeSelected && uoResult?.descrizioneUo
                 ? uoResult?.descrizioneUo.toLocaleLowerCase()
-                : (cfResult as any).businessName.toLocaleLowerCase()
+                : (cfResult as any).businessName
             }
             partyRole={
               !isTaxCodeSelected && aooResult

--- a/src/components/autocomplete/components/asyncAutocomplete/components/AsyncAutocompleteResultsCode.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/components/AsyncAutocompleteResultsCode.tsx
@@ -84,7 +84,7 @@ export default function AsyncAutocompleteResultsCode({
                 ? aooResult?.denominazioneAoo.toLocaleLowerCase()
                 : isUoCodeSelected && uoResult?.descrizioneUo
                 ? uoResult?.descrizioneUo.toLocaleLowerCase()
-                : visibleCode?.description
+                : (cfResult as any).businessName.toLocaleLowerCase()
             }
             partyRole={
               !isTaxCodeSelected && aooResult

--- a/src/components/autocomplete/components/asyncAutocomplete/components/AsyncAutocompleteSearch.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/components/AsyncAutocompleteSearch.tsx
@@ -94,7 +94,7 @@ export default function AsyncAutocompleteSearch({
       ? selected?.descrizioneUo
       : addUser && selected && (isAooCodeSelected || isUoCodeSelected) && selected?.description
       ? selected.description
-      : input;
+      : selected?.businessName;
 
   useEffect(() => {
     if (selected && selected?.denominazioneAoo) {

--- a/src/components/autocomplete/components/partyAdvancedSearchType/PartyAdvancedSelect.tsx
+++ b/src/components/autocomplete/components/partyAdvancedSearchType/PartyAdvancedSelect.tsx
@@ -87,7 +87,7 @@ export default function PartyAdvancedSelect({
   };
 
   useEffect(() => {
-    if(product?.id === 'prod-interop' && institutionType === 'SCP') {
+    if (product?.id === 'prod-interop' && institutionType === 'SCP') {
       onSelectValue(false, true, false, false, false);
       setTypeOfSearch('taxCode');
     }
@@ -110,7 +110,7 @@ export default function PartyAdvancedSelect({
   }, []);
 
   useEffect(() => {
-    if (addUser || institutionType === 'SCP') {
+    if (addUser || (product?.id === 'prod-interop' && institutionType === 'SCP')) {
       setTypeOfSearch('taxCode');
       setIsTaxCodeSelected(true);
     } else {

--- a/src/components/autocomplete/components/partyAdvancedSearchType/PartyAdvancedSelect.tsx
+++ b/src/components/autocomplete/components/partyAdvancedSearchType/PartyAdvancedSelect.tsx
@@ -59,9 +59,7 @@ export default function PartyAdvancedSelect({
 }: Props) {
   const { t } = useTranslation();
 
-  const [typeOfSearch, setTypeOfSearch] = useState(
-    product?.id === 'prod-interop' && institutionType === 'SCP' ? 'taxCode' : 'businessName'
-  );
+  const [typeOfSearch, setTypeOfSearch] = useState('businessName');
 
   const handleTypeSearchChange = (event: SelectChangeEvent) => {
     setTypeOfSearch(event.target.value as string);
@@ -87,6 +85,13 @@ export default function PartyAdvancedSelect({
     setUoResultHistory(undefined);
     setAooResultHistory(undefined);
   };
+
+  useEffect(() => {
+    if(product?.id === 'prod-interop' && institutionType === 'SCP') {
+      onSelectValue(false, true, false, false, false);
+      setTypeOfSearch('taxCode');
+    }
+  }, []);
 
   useEffect(() => {
     if (isBusinessNameSelected) {

--- a/src/components/autocomplete/components/partyAdvancedSearchType/PartyAdvancedSelect.tsx
+++ b/src/components/autocomplete/components/partyAdvancedSearchType/PartyAdvancedSelect.tsx
@@ -59,7 +59,9 @@ export default function PartyAdvancedSelect({
 }: Props) {
   const { t } = useTranslation();
 
-  const [typeOfSearch, setTypeOfSearch] = useState('businessName');
+  const [typeOfSearch, setTypeOfSearch] = useState(
+    product?.id === 'prod-interop' && institutionType === 'SCP' ? 'taxCode' : 'businessName'
+  );
 
   const handleTypeSearchChange = (event: SelectChangeEvent) => {
     setTypeOfSearch(event.target.value as string);
@@ -97,11 +99,13 @@ export default function PartyAdvancedSelect({
       setTypeOfSearch('uoCode');
     } else if (isIvassCodeSelected) {
       setTypeOfSearch('ivassCode');
+    } else {
+      setTypeOfSearch('');
     }
   }, []);
 
   useEffect(() => {
-    if (addUser) {
+    if (addUser || institutionType === 'SCP') {
       setTypeOfSearch('taxCode');
       setIsTaxCodeSelected(true);
     } else {
@@ -116,6 +120,7 @@ export default function PartyAdvancedSelect({
       product.id === 'prod-io-sign' ||
       product.id === 'prod-pn-dev' ||
       product.id === 'prod-pn');
+
   const optionsAvailable4InstitutionType =
     institutionType !== 'SA' && institutionType !== 'AS' && institutionType !== 'GSP';
 
@@ -146,7 +151,7 @@ export default function PartyAdvancedSelect({
         label={t('partyAdvancedSelect.advancedSearchLabel')}
         onChange={handleTypeSearchChange}
       >
-        {!addUser && (
+        {!addUser && institutionType !== 'SCP' && (
           <MenuItem
             id="businessName"
             data-testid="businessName"
@@ -178,6 +183,7 @@ export default function PartyAdvancedSelect({
 
         {((ENV.AOO_UO.SHOW_AOO_UO &&
           optionsAvailable4InstitutionType &&
+          institutionType !== 'SCP' &&
           filteredByProducts(product as Product)) ||
           (addUser && ENV.AOO_UO.SHOW_AOO_UO && filteredByProducts(selectedProduct))) &&
           menuItems.map((item) => (

--- a/src/components/steps/StepSearchParty.tsx
+++ b/src/components/steps/StepSearchParty.tsx
@@ -310,6 +310,11 @@ export function StepSearchParty({
                 inserisci uno dei dati richiesti e cerca l’ente per
                 <br /> cui vuoi richiedere l’adesione a <strong>Interoperabilità.</strong>
               </Trans>
+            ) : institutionType === 'SCP' ? (
+              <Trans i18nKey="onboardingStep1.onboarding.scpSubtitle">
+                Inserisci uno dei dati richiesti e cerca da Infocamere l’ente <br />
+                per cui vuoi richiedere l’adesione a <strong>Interoperabilità.</strong>
+              </Trans>
             ) : (
               subTitle
             )}
@@ -407,7 +412,7 @@ export function StepSearchParty({
           </Grid>
         )}
       </Grid>
-      {institutionType !== 'SA' && institutionType !== 'AS' && (
+      {institutionType !== 'SA' && institutionType !== 'AS' && institutionType !== 'SCP' && (
         <Grid container item justifyContent="center">
           <Grid item xs={6}>
             <Box
@@ -473,10 +478,10 @@ export function StepSearchParty({
           back={
             !productAvoidStep
               ? {
-                  action: onBackAction,
-                  label: t('stepInstitutionType.backLabel'),
-                  disabled: false,
-                }
+                action: onBackAction,
+                label: t('stepInstitutionType.backLabel'),
+                disabled: false,
+              }
               : undefined
           }
           forward={{

--- a/src/components/steps/StepSearchParty.tsx
+++ b/src/components/steps/StepSearchParty.tsx
@@ -311,8 +311,8 @@ export function StepSearchParty({
                 <br /> cui vuoi richiedere l’adesione a <strong>Interoperabilità.</strong>
               </Trans>
             ) : institutionType === 'SCP' ? (
-              <Trans i18nKey="onboardingStep1.onboarding.scpSubtitle">
-                Inserisci uno dei dati richiesti e cerca da Infocamere l’ente <br />
+              <Trans i18nKey="onboardingStep1.onboarding.scpSubtitle" components={{ 3: <br />, 5: <strong /> }}>
+                Inserisci uno dei dati richiesti e cerca da Infocamere l’ente <br/>
                 per cui vuoi richiedere l’adesione a <strong>Interoperabilità.</strong>
               </Trans>
             ) : (

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -994,6 +994,13 @@ export async function mockFetch(
     );
   }
 
+  if (endpoint === 'ONBOARDING_GET_PARTY_BY_CF_FROM_INFOCAMERE') {
+    const matchedParty = mockedParties.find((p) => p.taxCode === endpointParams.id);
+    return new Promise((resolve) =>
+      resolve({ data: matchedParty, status: 200, statusText: '200' } as AxiosResponse)
+    );
+  }
+
   if (endpoint === 'ONBOARDING_GET_AOO_CODE_INFO') {
     const retrievedAoo = mockedAoos.find((ao) => ao.codiceUniAoo === endpointParams.codiceUniAoo);
     return new Promise((resolve) =>

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -149,7 +149,7 @@ export default {
         'Se sei tra i gestori privati di piattaforma e-procurement e hai <1/> già ottenuto la <3>certificazione da AgID</3>, inserisci uno dei dati <5/> richiesti e cerca l’ente per cui vuoi richiedere l’adesione a <7/> <8>Interoperabilità.</8>',
       asSubTitle:
         'Se sei una società di assicurazione presente nell’Albo delle <1/>imprese IVASS, inserisci uno dei dati richiesti e cerca l’ente per<3/> cui vuoi richiedere l’adesione a <5>Interoperabilità.</5>',
-      scpSubtitle: 'Inserisci uno dei dati richiesti e cerca da Infocamere l’ente <3 /> per cui vuoi richiedere l’adesione a <5>Interoperabilità.</5>',
+      scpSubtitle: 'Inserisci uno dei dati richiesti e cerca da Infocamere l’ente <3/> per cui vuoi richiedere l’adesione a <5>Interoperabilità.</5>',
       asyncAutocomplete: {
         placeholder: 'Cerca',
       },

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -149,6 +149,7 @@ export default {
         'Se sei tra i gestori privati di piattaforma e-procurement e hai <1/> già ottenuto la <3>certificazione da AgID</3>, inserisci uno dei dati <5/> richiesti e cerca l’ente per cui vuoi richiedere l’adesione a <7/> <8>Interoperabilità.</8>',
       asSubTitle:
         'Se sei una società di assicurazione presente nell’Albo delle <1/>imprese IVASS, inserisci uno dei dati richiesti e cerca l’ente per<3/> cui vuoi richiedere l’adesione a <5>Interoperabilità.</5>',
+      scpSubtitle: 'Inserisci uno dei dati richiesti e cerca da Infocamere l’ente <3 /> per cui vuoi richiedere l’adesione a <5>Interoperabilità.</5>',
       asyncAutocomplete: {
         placeholder: 'Cerca',
       },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -129,6 +129,9 @@ export const API = {
   ONBOARDING_GET_INSURANCE_COMPANIES_FROM_IVASSCODE: {
     URL: ENV.URL_API.PARTY_REGISTRY_PROXY + '/insurance-companies/origin/{{code}}',
   },
+  ONBOARDING_GET_PARTY_BY_CF_FROM_INFOCAMERE: {
+    URL: ENV.URL_API.PARTY_REGISTRY_PROXY + '/infocamere-pdnd/institution/{{id}}',
+  },
   ONBOARDING_GET_PRODUCTS: {
     URL: ENV.URL_API.ONBOARDING + '/products',
   },
@@ -171,8 +174,8 @@ export const filterByCategory = (institutionType?: string, productId?: string) =
   productId === 'prod-pn'
     ? 'L6,L4,L45,L35,L5,L17,L15,C14'
     : institutionType === 'GSP'
-    ? 'L37,SAG'
-    : 'C17,C16,L10,L19,L13,L2,C10,L20,L21,L22,L15,L1,C13,C5,L40,L11,L39,L46,L8,L34,L7,L35,L45,L47,L6,L12,L24,L28,L42,L36,L44,C8,C3,C7,C14,L16,C11,L33,C12,L43,C2,L38,C1,L5,L4,L31,L18,L17,S01,SA';
+      ? 'L37,SAG'
+      : 'C17,C16,L10,L19,L13,L2,C10,L20,L21,L22,L15,L1,C13,C5,L40,L11,L39,L46,L8,L34,L7,L35,L45,L47,L6,L12,L24,L28,L42,L36,L44,C8,C3,C7,C14,L16,C11,L33,C12,L43,C2,L38,C1,L5,L4,L31,L18,L17,S01,SA';
 
 export const noMandatoryIpaProducts = (productId?: string) =>
   productId !== 'prod-interop' &&

--- a/src/views/onboardingProduct/OnboardingProduct.tsx
+++ b/src/views/onboardingProduct/OnboardingProduct.tsx
@@ -612,7 +612,8 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
       newInstitutionType !== 'GSP' &&
       newInstitutionType !== 'PA' &&
       newInstitutionType !== 'SA' &&
-      newInstitutionType !== 'AS'
+      newInstitutionType !== 'AS' &&
+      newInstitutionType !== 'SCP'
     ) {
       if (newInstitutionType !== institutionType) {
         setOnboardingFormData({


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-5173] feat: API invocation for private body search via CF

#### Motivation and Context

As a user of an organization who wants to subscribe to a product, I want to be able to select my organization by searching for it by tax code on the Infocamere data source

#### How Has This Been Tested?

tested if inserting a taxCode the API on the infocamere data source retrives the wanted data

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5173]: https://pagopa.atlassian.net/browse/SELC-5173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ