### PR TITLE
[SELC-5273] feat: Invocation checkRecipientCode API

### DIFF
--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -930,6 +930,14 @@ const mockedOnboardingRequestData: Array<OnboardingRequestData> = [
   },
 ];
 
+const getRandomRecipientCodeStatus = (obj: { [key: string]: string }): string => {
+  const keys = Object.keys(obj);
+  const randomKey = keys[Math.floor(Math.random() * keys.length)];
+  return obj[randomKey];
+};
+
+const mockRecipientCodeValidation = {accepted: 'ACCEPTED', denied_no_ass: 'DENIED_NO_ASSOCIATION', denied_no_bill: 'DENIED_NO_BILLING'};
+
 const noContent: Promise<AxiosResponse> = new Promise((resolve) =>
   resolve({
     status: 204,
@@ -1042,6 +1050,13 @@ export async function mockFetch(
     const matchedParty = mockedPartyFromInfoCamere.find((p) => p.businessTaxId === endpointParams.id);
     return new Promise((resolve) =>
       resolve({ data: matchedParty, status: 200, statusText: '200' } as AxiosResponse)
+    );
+  }
+
+  if (endpoint === 'ONBOARDING_RECIPIENT_CODE_VALIDATION') {
+    const randomStatus = getRandomRecipientCodeStatus(mockRecipientCodeValidation);
+    return new Promise((resolve) =>
+      resolve({ data: randomStatus, status: 200, statusText: '200'} as AxiosResponse)
     );
   }
 

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -606,6 +606,8 @@ export default {
       invalidReaField: 'Il Campo REA non è valido',
       invalidMailSupport: 'L’indirizzo email non è valido',
       invalidShareCapitalField: 'Il campo capitale sociale non è valido',
+      invalidRecipientCodeNoAssociation: 'Il codice inserito non è associato al tuo ente',
+      invalidRecipientCodeNoBilling: 'Il codice inserito è associato al codice fiscale di un ente che non ha il servizio di fatturazione attivo',
       vatNumberAlreadyRegistered: 'La P. IVA che hai inserito è già stata registrata.',
       vatNumberVerificationErrorTitle: 'La verifica non è andata a buon fine',
       vatNumberVerificationErrorDescription:

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -96,6 +96,9 @@ export const API = {
   ONBOARDING_TOKEN_VALIDATION: {
     URL: ENV.URL_API.ONBOARDING_V2 + '/v2/tokens/{{onboardingId}}/verify',
   },
+  ONBOARDING_RECIPIENT_CODE_VALIDATION: {
+    URL: ENV.URL_API.ONBOARDING_V2 + '/v2/institutions/onboarding/recipientCode/verification',
+  },
   ONBOARDING_GET_CONTRACT: {
     URL: ENV.URL_API.ONBOARDING_V2 + '/v2/tokens/{{onboardingId}}/contract',
   },

--- a/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
+++ b/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
@@ -261,7 +261,7 @@ test.skip('test billingData without Support Mail', async () => {
 test('test complete onboarding AOO with product interop', async () => {
   renderComponent('prod-interop');
   await executeStepInstitutionType('prod-interop');
-  await executeAdvancedSearchForAoo();
+  await executeAdvancedSearchForAoo(); 
   await executeStep2();
   await executeStep3(true);
   const onboardingCompleted = await waitFor(() =>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-5273] feat: Invocation checkRecipientCode API

#### Motivation and Context

If the user enters an invalid SDI code, one of the error messages will be displayed.
In the case of AOO and central body, show the SDI code field empty.
the empty SDI code field will be displayed if the OU does not have a billing service.

#### How Has This Been Tested?

Tested, by inserting three different SDI codes, all the responses of the checkRecipientCode API and all the error cases on the text field of recipientCode ("Unique code or SDI")

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.