### PR TITLE
[SELC-5314] feat: SFE Billing Code field validation

### DIFF
--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -803,6 +803,9 @@ export default function PersonalAndBillingDataSection({
                         setInvalidTaxCodeInvoicing(false);
                       }
                     }}
+                    inputProps={{
+                      maxLength: 11,
+                    }}
                   />
                 </Grid>
               )}

--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -166,15 +166,6 @@ export default function PersonalAndBillingDataSection({
     }
   }, [aooSelected]);
 
-  useEffect(() => {
-    if (formik.values.recipientCode && formik.values.recipientCode.length === 6) {
-      void verifyRecipientCodeIsValid(
-        formik.values.recipientCode,
-        (selectedParty as Party)?.originId
-      );
-    }
-  }, [formik.values.recipientCode]);
-
   const baseNumericFieldProps = (
     field: keyof OnboardingFormData,
     label: string,
@@ -206,32 +197,6 @@ export default function PersonalAndBillingDataSection({
         },
       },
     };
-  };
-
-  const validateRecipientCode = (recipientCodeStatus: string) => {
-    if (
-      canInvoice &&
-      formik.values.recipientCode &&
-      formik.values.recipientCode.length === 6 &&
-      recipientCodeStatus === 'DENIED_NO_ASSOCIATION'
-    ) {
-      formik.setFieldError(
-        'recipientCode',
-        t('onboardingFormData.billingDataSection.invalidRecipientCodeNoAssociation')
-      );
-    } else if (
-      canInvoice &&
-      formik.values.recipientCode &&
-      formik.values.recipientCode.length === 6 &&
-      recipientCodeStatus === 'DENIED_NO_BILLING'
-    ) {
-      formik.setFieldError(
-        'recipientCode',
-        t('onboardingFormData.billingDataSection.invalidRecipientCodeNoBilling')
-      );
-    } else {
-      formik.setFieldError('recipientCode', undefined);
-    }
   };
 
   const getCountriesFromGeotaxonomies = async (query: string) => {
@@ -340,34 +305,6 @@ export default function PersonalAndBillingDataSection({
         setInvalidTaxCodeInvoicing(false);
       } else {
         setInvalidTaxCodeInvoicing(true);
-      }
-    }
-  };
-
-  const verifyRecipientCodeIsValid = async (recipientCode: string, originId: string) => {
-    const getRecipientCodeValidation = await fetchWithLogs(
-      {
-        endpoint: 'ONBOARDING_RECIPIENT_CODE_VALIDATION',
-      },
-      {
-        method: 'GET',
-        params: {
-          recipientCode,
-          originId,
-        },
-      },
-      () => setRequiredLogin(true)
-    );
-
-    const outcome = getFetchOutcome(getRecipientCodeValidation);
-
-    if (outcome === 'success') {
-      const result = (getRecipientCodeValidation as AxiosResponse).data;
-      if (result) {
-        validateRecipientCode(result);
-        if (uoSelected && result === 'DENIED_NO_BILLING') {
-          formik.setFieldValue('recipientCode', undefined);
-        }
       }
     }
   };
@@ -849,7 +786,7 @@ export default function PersonalAndBillingDataSection({
                   }}
                 />
               )}
-              {uoSelected && canInvoice && (
+              {(uoSelected || institutionType === 'PA') && canInvoice && (
                 <Grid item xs={12} mt={3}>
                   <CustomTextField
                     {...baseTextFieldProps(

--- a/src/components/onboardingFormData/__tests__/PersonalAndBillingDataSection.test.tsx
+++ b/src/components/onboardingFormData/__tests__/PersonalAndBillingDataSection.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { useFormik } from 'formik';
 import React from 'react';
 import { OnboardingFormData } from '../../../model/OnboardingFormData';
@@ -198,9 +198,12 @@ test('Test: Rendered PersonalAndBillingDataSection component with all possible b
     );
     const rea = screen.queryByText('REA');
     const sdiCode = screen.queryByText('Codice univoco o SDI');
+    const taxCodeSfe = screen.queryByText('Codice Fiscale SFE');
     const shareCapital = screen.queryByText('Capitale sociale (facoltativo)');
     const visibleCitizenMail = screen.queryByText('Indirizzo email visibile ai cittadini');
-    const visibleCitizenMailOptional = screen.queryByText('Indirizzo email visibile ai cittadini (facoltativo)');
+    const visibleCitizenMailOptional = screen.queryByText(
+      'Indirizzo email visibile ai cittadini (facoltativo)'
+    );
 
     if (aooSelected) {
       expect(businessName).not.toBeInTheDocument();
@@ -243,8 +246,10 @@ test('Test: Rendered PersonalAndBillingDataSection component with all possible b
 
     if (canInvoice) {
       expect(sdiCode).toBeInTheDocument();
+      expect(taxCodeSfe).toBeInTheDocument();
     } else {
       expect(sdiCode).not.toBeInTheDocument();
+      expect(taxCodeSfe).not.toBeInTheDocument();
     }
 
     if (isInformationCompany) {
@@ -260,7 +265,9 @@ test('Test: Rendered PersonalAndBillingDataSection component with all possible b
     if (institutionAvoidGeotax) {
       expect(visibleCitizenMail).not.toBeInTheDocument();
     } else {
-      expect(productId === "prod-io" ? visibleCitizenMail : visibleCitizenMailOptional).toBeInTheDocument();
+      expect(
+        productId === 'prod-io' ? visibleCitizenMail : visibleCitizenMailOptional
+      ).toBeInTheDocument();
     }
 
     const isTaxCodeEquals2PIVA = document.getElementById('taxCodeEquals2VatNumber');

--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -363,7 +363,7 @@ export default function StepOnboardingFormData({
       }
       setRecipientCodeStatus(result);
     } else {
-      void formik.setFieldError('recipientCode', t('onboardingFormData.billingDataSection.invalidRecipientCodeNoAssociation'));
+      setRecipientCodeStatus('DENIED_NO_ASSOCIATION');
     }
   };
 
@@ -404,6 +404,10 @@ export default function StepOnboardingFormData({
         formik.values.recipientCode,
         (selectedParty as Party)?.originId
       );
+    }
+    
+    if(formik.values.recipientCode && formik.values.recipientCode.length === 7) {
+      setRecipientCodeStatus(undefined);
     }
   }, [formik.values.recipientCode]);
 

--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -90,7 +90,7 @@ export default function StepOnboardingFormData({
   );
   const [retrievedIstat, setRetrievedIstat] = useState<string>();
   const [invalidTaxCodeInvoicing, setInvalidTaxCodeInvoicing] = useState<boolean>(false);
-
+  const [recipientCodeStatus, setRecipientCodeStatus] = useState<string>();
   const [geotaxonomy, updateGeotaxonomy] = useReducer(
     (prev: { add: boolean; edit: boolean }, next: { add: boolean; edit: boolean }) => ({
       ...prev,
@@ -227,8 +227,8 @@ export default function StepOnboardingFormData({
       vatNumber: stepHistoryState.isTaxCodeEquals2PIVA
         ? formik.values.taxCode
         : formik.values.hasVatnumber && !formik.values.isForeignInsurance
-        ? formik.values.vatNumber
-        : undefined,
+          ? formik.values.vatNumber
+          : undefined,
       taxCode:
         formik.values.taxCode !== '' && formik.values.taxCode ? formik.values.taxCode : undefined,
     });
@@ -271,6 +271,7 @@ export default function StepOnboardingFormData({
         institutionAvoidGeotax,
         isPremium,
         invalidTaxCodeInvoicing,
+        recipientCodeStatus,
         productId
       )
     );
@@ -294,6 +295,7 @@ export default function StepOnboardingFormData({
     vatVerificationGenericError,
     formik.values,
     invalidTaxCodeInvoicing,
+    recipientCodeStatus
   ]);
 
   useEffect(() => {
@@ -337,6 +339,34 @@ export default function StepOnboardingFormData({
     }
   };
 
+  const verifyRecipientCodeIsValid = async (recipientCode: string, originId: string) => {
+    const getRecipientCodeValidation = await fetchWithLogs(
+      {
+        endpoint: 'ONBOARDING_RECIPIENT_CODE_VALIDATION',
+      },
+      {
+        method: 'GET',
+        params: {
+          recipientCode,
+          originId,
+        },
+      },
+      () => setRequiredLogin(true)
+    );
+
+    const outcome = getFetchOutcome(getRecipientCodeValidation);
+
+    if (outcome === 'success') {
+      const result = (getRecipientCodeValidation as AxiosResponse).data;
+      if (uoSelected && result && result === 'DENIED_NO_BILLING') {
+        void formik.setFieldValue('recipientCode', undefined);
+      }
+      setRecipientCodeStatus(result);
+    } else {
+      void formik.setFieldError('recipientCode', t('onboardingFormData.billingDataSection.invalidRecipientCodeNoAssociation'));
+    }
+  };
+
   useEffect(() => {
     if (
       !stepHistoryState.isTaxCodeEquals2PIVA &&
@@ -367,6 +397,15 @@ export default function StepOnboardingFormData({
       void verifyVatNumber();
     }
   }, [formik.values.vatNumber, stepHistoryState.isTaxCodeEquals2PIVA]);
+
+  useEffect(() => {
+    if (formik.values.recipientCode && formik.values.recipientCode.length === 6) {
+      void verifyRecipientCodeIsValid(
+        formik.values.recipientCode,
+        (selectedParty as Party)?.originId
+      );
+    }
+  }, [formik.values.recipientCode]);
 
   const baseTextFieldProps = (
     field: keyof OnboardingFormData,

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -515,7 +515,7 @@ export const mockedAoos: Array<AooData> = [
 
 export const mockedUos: Array<UoData> = [
   {
-    codiceFiscaleEnte: '98765432109',
+    codiceFiscaleEnte: '00000000000',
     codiceFiscaleSfe: '87654321098',
     codiceIpa: 'ABCDEF12',
     codiceUniUo: 'UF9YK7',
@@ -1058,10 +1058,11 @@ export async function mockFetch(
 
   if (endpoint === 'ONBOARDING_RECIPIENT_CODE_VALIDATION') {
     const mockAcceptedResponse = mockRecipientCodeValidation.filter((r) => r.code === params.recipientCode);
-  const responseValue = mockAcceptedResponse[0]?.value.length > 0 ?  mockAcceptedResponse[0].value : '';
-    return new Promise((resolve) =>
-      resolve({ data: responseValue, status: 200, statusText: '200' } as AxiosResponse)
-    );
+    if (mockAcceptedResponse.length > 0) {
+      return new Promise((resolve) => { resolve({ data: mockAcceptedResponse[0]?.value, status: 200, statusText: '200' } as AxiosResponse); });
+    } else {
+      return notFoundError;
+    }
   }
 
   if (endpoint === 'ONBOARDING_GET_AOO_CODE_INFO') {

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -1057,9 +1057,17 @@ export async function mockFetch(
   }
 
   if (endpoint === 'ONBOARDING_RECIPIENT_CODE_VALIDATION') {
-    const mockAcceptedResponse = mockRecipientCodeValidation.filter((r) => r.code === params.recipientCode);
+    const mockAcceptedResponse = mockRecipientCodeValidation.filter(
+      (r) => r.code === params.recipientCode
+    );
     if (mockAcceptedResponse.length > 0) {
-      return new Promise((resolve) => { resolve({ data: mockAcceptedResponse[0]?.value, status: 200, statusText: '200' } as AxiosResponse); });
+      return new Promise((resolve) => {
+        resolve({
+          data: mockAcceptedResponse[0]?.value,
+          status: 200,
+          statusText: '200',
+        } as AxiosResponse);
+      });
     } else {
       return notFoundError;
     }
@@ -1080,7 +1088,7 @@ export async function mockFetch(
   }
 
   if (endpoint === 'ONBOARDING_GET_UO_LIST') {
-    const retrievedUos = mockedUos.filter((uo) => uo.codiceFiscaleEnte === params.taxCodeInvoicing);
+    const retrievedUos = mockedUos.filter((uo) => uo.codiceFiscaleSfe === params.taxCodeInvoicing);
     return new Promise((resolve) =>
       resolve({
         data: { items: retrievedUos, count: retrievedUos.length },

--- a/src/utils/validateFields.ts
+++ b/src/utils/validateFields.ts
@@ -30,6 +30,7 @@ export const validateFields = (
   institutionAvoidGeotax: boolean,
   isPremium: boolean,
   invalidTaxCodeInvoicing: boolean,
+  recipientCodeStatus?: string,
   productId?: string
 ) =>
   Object.entries({
@@ -127,7 +128,15 @@ export const validateFields = (
           !emailRegexp.test(values.dpoPecAddress)
         ? t('onboardingFormData.billingDataSection.invalidEmail')
         : undefined,
-    recipientCode: canInvoice && !values.recipientCode ? requiredError : undefined,
+    recipientCode: canInvoice
+      ? values.recipientCode && values.recipientCode.length === 6
+        ? recipientCodeStatus === 'DENIED_NO_ASSOCIATION'
+          ? t('onboardingFormData.billingDataSection.invalidRecipientCodeNoAssociation')
+          : recipientCodeStatus === 'DENIED_NO_BILLING'
+          ? t('onboardingFormData.billingDataSection.invalidRecipientCodeNoBilling')
+          : undefined
+        : requiredError
+      : undefined,
     geographicTaxonomies:
       ENV.GEOTAXONOMY.SHOW_GEOTAXONOMY &&
       !institutionAvoidGeotax &&

--- a/src/utils/validateFields.ts
+++ b/src/utils/validateFields.ts
@@ -129,7 +129,7 @@ export const validateFields = (
         ? t('onboardingFormData.billingDataSection.invalidEmail')
         : undefined,
     recipientCode: canInvoice
-      ? values.recipientCode && values.recipientCode.length === 6
+      ? values.recipientCode && values.recipientCode.length >= 6
         ? recipientCodeStatus === 'DENIED_NO_ASSOCIATION'
           ? t('onboardingFormData.billingDataSection.invalidRecipientCodeNoAssociation')
           : recipientCodeStatus === 'DENIED_NO_BILLING'

--- a/src/views/onboardingPremium/__tests__/OnboardingPremium.test.tsx
+++ b/src/views/onboardingPremium/__tests__/OnboardingPremium.test.tsx
@@ -250,7 +250,6 @@ const executeStepBillingData = async () => {
   expect(partyWithoutVatNumberCheckbox).toBeChecked();
 
   const confirmButtonEnabled = screen.getByRole('button', { name: 'Continua' });
-  await waitFor(() => expect(confirmButtonEnabled).toBeEnabled());
 
   fireEvent.change(document.getElementById('recipientCode') as HTMLElement, {
     target: { value: '' },

--- a/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
+++ b/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
@@ -482,7 +482,7 @@ const executeAdvancedSearchForAoo = async () => {
   const vatNumber = document.getElementById('vatNumber') as HTMLInputElement;
 
   fireEvent.change(vatNumber as HTMLElement, {
-    target: { value: 'AAAAAA44D55F456K' },
+    target: { value: '00000000000' },
   });
 
   const continueButton = await waitFor(() => screen.getByRole('button', { name: 'Continua' }));
@@ -622,6 +622,10 @@ const executeStepBillingData = async () => {
     target: { value: 'A1B2C3' },
   });
 
+  fireEvent.change(document.getElementById('taxCodeInvoicing') as HTMLElement, {
+    target: { value: '00000000000' }
+  });
+
   await waitFor(() => expect(confirmButtonEnabled).toBeEnabled());
 
   await checkCorrectBodyBillingData(
@@ -629,8 +633,8 @@ const executeStepBillingData = async () => {
     'registeredOfficeInput',
     'a@a.it',
     '09010',
-    'AAAAAA44D55F456K',
-    'AAAAAA44D55F456K',
+    '00000000000',
+    '00000000000',
     'A1B2C3'
   );
   fireEvent.click(confirmButtonEnabled);
@@ -792,9 +796,9 @@ const executeStepBillingDataWithoutSupportMail = async () => {
     'registeredOfficeInput',
     'a@a.it',
     '09010',
-    'AAAAAA44D55F456K',
-    'AAAAAA44D55F456K',
-    'A1B2C3D'
+    '00000000000',
+    '00000000000',
+    'A1B2C3'
   );
   fireEvent.click(confirmButton);
   await waitFor(() => screen.getByText(step2Title));
@@ -901,20 +905,15 @@ const fillUserBillingDataForm = async (
   });
   fireEvent.change(document.getElementById(zipCode) as HTMLElement, { target: { value: '09010' } });
   fireEvent.change(document.getElementById(taxCodeInput) as HTMLElement, {
-    target: { value: 'AAAAAA44D55F456K' },
+    target: { value: '00000000000' },
   });
 
   const isTaxCodeEquals2PIVA = document.getElementById('taxCodeEquals2VatNumber');
   expect(isTaxCodeEquals2PIVA).toBeTruthy();
 
   fireEvent.change(document.getElementById(vatNumber) as HTMLElement, {
-    target: { value: 'AAAAAA44D55F456K' },
+    target: { value: '00000000000' },
   });
-
-  const taxCodeInvoicing = document.getElementById('taxCodeInvoicing');
-  if (taxCodeInvoicing) {
-    fireEvent.change(taxCodeInvoicing, { target: { value: 'AAAAAA44D55F456K' } });
-  }
 
   fireEvent.change(document.getElementById(recipientCode) as HTMLElement, {
     target: { value: 'A1B2C3D' },
@@ -1209,9 +1208,9 @@ const billingData2billingDataRequest = () => ({
   registeredOffice: 'registeredOfficeInput',
   digitalAddress: 'a@a.it',
   zipCode: '09010',
-  taxCode: 'AAAAAA44D55F456K',
-  taxCodeInvoicing: 'AAAAAA44D55F456K',
-  vatNumber: 'AAAAAA44D55F456K',
+  taxCode: '00000000000',
+  taxCodeInvoicing: '00000000000',
+  vatNumber: '00000000000',
   recipientCode: 'A1B2C3'.toUpperCase(),
 });
 
@@ -1264,7 +1263,7 @@ const verifySubmit = async (productId = 'prod-idpay') => {
           productId,
           subunitCode: undefined,
           subunitType: undefined,
-          taxCode: 'AAAAAA44D55F456K',
+          taxCode: '00000000000',
           companyInformations: undefined,
           aggregates: undefined,
           additionalInformations: undefined,
@@ -1320,7 +1319,7 @@ const verifySubmitPt = async (productId = 'prod-io-sign') => {
           productId,
           subunitCode: undefined,
           subunitType: undefined,
-          taxCode: 'AAAAAA44D55F456K',
+          taxCode: '00000000000',
           companyInformations: {
             businessRegisterPlace: undefined,
             rea: undefined,

--- a/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
+++ b/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
@@ -259,7 +259,7 @@ test.skip('test billingData without Support Mail', async () => {
 test('test complete onboarding AOO with product interop', async () => {
   renderComponent('prod-interop');
   await executeStepInstitutionType('prod-interop');
-  await executeAdvancedSearchForAoo(); 
+  await executeAdvancedSearchForAoo();
   await executeStep2();
   await executeStep3(true);
   const onboardingCompleted = await waitFor(() =>
@@ -619,11 +619,32 @@ const executeStepBillingData = async () => {
   );
 
   fireEvent.change(document.getElementById('recipientCode') as HTMLElement, {
+    target: { value: 'AABBC1' },
+  });
+  await waitFor(() => screen.getByText('Il codice inserito non è associato al tuo ente'));
+
+  fireEvent.change(document.getElementById('recipientCode') as HTMLElement, {
+    target: { value: '2A3B4C' },
+  });
+  await waitFor(() =>
+    screen.getByText(
+      'Il codice inserito è associato al codice fiscale di un ente che non ha il servizio di fatturazione attivo'
+    )
+  );
+
+  fireEvent.change(document.getElementById('recipientCode') as HTMLElement, {
     target: { value: 'A1B2C3' },
   });
 
   fireEvent.change(document.getElementById('taxCodeInvoicing') as HTMLElement, {
-    target: { value: '00000000000' }
+    target: { value: '87654321092' },
+  });
+  await waitFor(() => screen.getByText('Il Codice Fiscale inserito non è relativo al tuo ente'));
+
+  await waitFor(() => expect(confirmButtonEnabled).toBeDisabled());
+
+  fireEvent.change(document.getElementById('taxCodeInvoicing') as HTMLElement, {
+    target: { value: '87654321098' },
   });
 
   await waitFor(() => expect(confirmButtonEnabled).toBeEnabled());
@@ -1209,7 +1230,7 @@ const billingData2billingDataRequest = () => ({
   digitalAddress: 'a@a.it',
   zipCode: '09010',
   taxCode: '00000000000',
-  taxCodeInvoicing: '00000000000',
+  taxCodeInvoicing: '87654321098',
   vatNumber: '00000000000',
   recipientCode: 'A1B2C3'.toUpperCase(),
 });
@@ -1267,7 +1288,7 @@ const verifySubmit = async (productId = 'prod-idpay') => {
           companyInformations: undefined,
           aggregates: undefined,
           additionalInformations: undefined,
-          isAggregator: undefined
+          isAggregator: undefined,
         },
         method: 'POST',
       },

--- a/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
+++ b/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
@@ -108,12 +108,6 @@ test('onboarding of pa with origin IPA', async () => {
   renderComponent('prod-pagopa');
   await executeStepInstitutionType('prod-pagopa');
   await executeStep1('AGENCY X', 'prod-pagopa', 'PA');
-  
-  // const searchCitySelect = document.getElementById('city-select') as HTMLInputElement;
-  // const searchCounty = document.getElementById('county');
-
-  // await waitFor(() => expect(searchCitySelect.value).toBe('Palermo'));
-  // await waitFor(() => expect(searchCounty).toBeDisabled());
   await fillUserBillingDataForm(
     'businessName',
     'registeredOffice',
@@ -124,6 +118,10 @@ test('onboarding of pa with origin IPA', async () => {
     'recipientCode',
     'supportEmail'
   );
+
+  fireEvent.change(document.getElementById('recipientCode') as HTMLElement, {
+    target: { value: 'A1B2C3' },
+  });
 
   const confirmButtonEnabled = screen.getByRole('button', { name: 'Continua' });
   await waitFor(() => expect(confirmButtonEnabled).toBeEnabled());
@@ -594,6 +592,10 @@ const executeStepBillingData = async () => {
     'province'
   );
 
+  fireEvent.change(document.getElementById('recipientCode') as HTMLElement, {
+    target: { value: 'A1B2C3' },
+  });
+
   const confirmButtonEnabled = screen.getByRole('button', { name: 'Continua' });
   await waitFor(() => expect(confirmButtonEnabled).toBeEnabled());
 
@@ -616,6 +618,10 @@ const executeStepBillingData = async () => {
     'province'
   );
 
+  fireEvent.change(document.getElementById('recipientCode') as HTMLElement, {
+    target: { value: 'A1B2C3' },
+  });
+
   await waitFor(() => expect(confirmButtonEnabled).toBeEnabled());
 
   await checkCorrectBodyBillingData(
@@ -625,7 +631,7 @@ const executeStepBillingData = async () => {
     '09010',
     'AAAAAA44D55F456K',
     'AAAAAA44D55F456K',
-    'A1B2C3D'
+    'A1B2C3'
   );
   fireEvent.click(confirmButtonEnabled);
   await waitFor(() => screen.getByText(step2Title));
@@ -904,6 +910,12 @@ const fillUserBillingDataForm = async (
   fireEvent.change(document.getElementById(vatNumber) as HTMLElement, {
     target: { value: 'AAAAAA44D55F456K' },
   });
+
+  const taxCodeInvoicing = document.getElementById('taxCodeInvoicing');
+  if (taxCodeInvoicing) {
+    fireEvent.change(taxCodeInvoicing, { target: { value: 'AAAAAA44D55F456K' } });
+  }
+
   fireEvent.change(document.getElementById(recipientCode) as HTMLElement, {
     target: { value: 'A1B2C3D' },
   });
@@ -1198,8 +1210,9 @@ const billingData2billingDataRequest = () => ({
   digitalAddress: 'a@a.it',
   zipCode: '09010',
   taxCode: 'AAAAAA44D55F456K',
+  taxCodeInvoicing: 'AAAAAA44D55F456K',
   vatNumber: 'AAAAAA44D55F456K',
-  recipientCode: 'A1B2C3D'.toUpperCase(),
+  recipientCode: 'A1B2C3'.toUpperCase(),
 });
 
 const verifySubmit = async (productId = 'prod-idpay') => {
@@ -1254,6 +1267,8 @@ const verifySubmit = async (productId = 'prod-idpay') => {
           taxCode: 'AAAAAA44D55F456K',
           companyInformations: undefined,
           aggregates: undefined,
+          additionalInformations: undefined,
+          isAggregator: undefined
         },
         method: 'POST',
       },


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-5314] feat: SFE Billing Code field validation

#### Motivation and Context

the field for sfe has to be free and be validated calling the API verifyTaxCodeInvoicing

#### How Has This Been Tested?

Tested if when landing in page the field SFE is free and editable.
Tested if at the change of the value SFE field the API verifyTaxCodeInvoicing has been called with the correct values and that has been retrived the correct response.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5314]: https://pagopa.atlassian.net/browse/SELC-5314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ