### PR TITLE
[SELC-5137] feat: Standardize the title of the data page for all prod…

### DIFF
--- a/src/components/onboardingFormData/Heading.tsx
+++ b/src/components/onboardingFormData/Heading.tsx
@@ -1,30 +1,19 @@
 import { Grid, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { InstitutionType } from '../../../types';
 
 type Props = {
-  institutionType: InstitutionType;
-  isPaymentServiceProvider: boolean;
   subtitle: string | JSX.Element;
-  productId?: string;
 };
 
 export default function Heading({
-  institutionType,
-  isPaymentServiceProvider,
   subtitle,
-  productId,
 }: Props) {
   const { t } = useTranslation();
   return (
     <Grid container sx={{ textAlign: 'center', justifyContent: 'center' }}>
       <Grid item xs={12}>
         <Typography variant="h3" component="h2" sx={{ lineHeight: '1.2' }}>
-          {isPaymentServiceProvider || productId === 'prod-pagopa'
-            ? t('onboardingFormData.pspAndProdPagoPATitle')
-            : institutionType === 'PT'
-            ? t('onboardingFormData.billingDataPt.title')
-            : t('onboardingFormData.title')}
+          {t('onboardingFormData.title')}
         </Typography>
       </Grid>
       <Grid item xs={12} marginTop={1} marginBottom={4}>

--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -405,12 +405,7 @@ export default function StepOnboardingFormData({
   ) : (
     <Box display="flex" justifyContent="center">
       <Grid container item xs={8} display="flex" justifyContent="center">
-        <Heading
-          institutionType={institutionType}
-          productId={productId}
-          subtitle={subtitle}
-          isPaymentServiceProvider={isPaymentServiceProvider}
-        />
+        <Heading subtitle={subtitle} />
         <PersonalAndBillingDataSection
           productId={productId}
           origin={origin}

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -596,7 +596,7 @@ export default {
     confirmLabel: 'Continua',
   },
   onboardingFormData: {
-    title: 'Indica i dati del tuo ente',
+    title: 'Inserisci i dati dell’ente',
     pspAndProdPagoPATitle: 'Inserisci i dati',
     backLabel: 'Indietro',
     confirmLabel: 'Continua',

--- a/src/views/onboardingPremium/__tests__/OnboardingPremium.test.tsx
+++ b/src/views/onboardingPremium/__tests__/OnboardingPremium.test.tsx
@@ -98,7 +98,7 @@ const renderComponent = (
 };
 
 const stepSelectInstitutionReleatedTitle = 'Seleziona il tuo ente';
-const stepBillingDataTitle = 'Indica i dati del tuo ente';
+const stepBillingDataTitle = 'Inserisci i dati dell’ente';
 const stepAddManagerTitle = 'Indica il Legale Rappresentante';
 const successOnboardingSubProductTitle = 'La richiesta di adesione è stata inviata con successo';
 const errorOnboardingSubProductTitle = 'Qualcosa è andato storto';

--- a/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
+++ b/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
@@ -92,7 +92,7 @@ const renderComponent = (productId: string = 'prod-pn') => {
 
 const step1Title = 'Cerca il tuo ente';
 const stepInstitutionType = 'Seleziona il tipo di ente che rappresenti';
-const stepBillingDataTitle = 'Indica i dati del tuo ente';
+const stepBillingDataTitle = 'Inserisci i dati dell’ente';
 const step2Title = 'Indica il Legale Rappresentante';
 const step3Title = "Indica l'Amministratore";
 
@@ -575,7 +575,7 @@ const executeStepInstitutionTypeGspForProdIoSign = async () => {
   expect(confirmButtonEnabled).toBeEnabled();
 
   fireEvent.click(confirmButtonEnabled);
-  await waitFor(() => screen.getByText('Indica i dati del tuo ente'));
+  await waitFor(() => screen.getByText(stepBillingDataTitle));
 };
 
 const executeStepBillingData = async () => {
@@ -636,7 +636,7 @@ const executeStepBillingDataLabels = async () => {
 
   const backButton = screen.getByRole('button', { name: 'Indietro' });
 
-  await waitFor(() => screen.getByText('Indica i dati del tuo ente'));
+  await waitFor(() => screen.getByText(stepBillingDataTitle));
   expect(screen.getByText('Codice SDI'));
 
   expect(backButton).toBeEnabled();


### PR DESCRIPTION
…ucts and all actors in the onboarding flow

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-5137] feat: Standardize the title of the data page for all products and all actors in the onboarding flow

#### Motivation and Context

Uniform all the titles for the data page in the onboarding flow

#### How Has This Been Tested?

Tested that for all the products and actors in the data page they have all the same title

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5137]: https://pagopa.atlassian.net/browse/SELC-5137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ