### PR TITLE
[SELC-5344] feat: Show the "Codice Fiscale SFE" field under the "Codice univoco o SDI" field.

### DIFF
--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -832,33 +832,6 @@ export default function PersonalAndBillingDataSection({
                   }}
                 />
               )}
-              {(uoSelected || institutionType === 'PA') &&
-                canInvoice &&
-                taxCodeInvoicingVisible && (
-                  <Grid item xs={12} mt={3}>
-                    <CustomTextField
-                      {...baseTextFieldProps(
-                        'taxCodeInvoicing',
-                        t('onboardingFormData.billingDataSection.taxCodeInvoicing'),
-                        600,
-                        theme.palette.text.primary
-                      )}
-                      onChange={(e) => {
-                        formik.setFieldValue('taxCodeInvoicing', e.target.value);
-                        if (e.target.value.length === 11) {
-                          void verifyTaxCodeInvoicing(e.target.value);
-                        } else {
-                          setInvalidTaxCodeInvoicing(false);
-                        }
-                      }}
-                      inputProps={{
-                        maxLength: 11,
-                      }}
-                      disabled={disableTaxCodeInvoicing}
-                    />
-                  </Grid>
-                )}
-
               {isPaymentServiceProvider && formik.values.hasVatnumber && (
                 <Box display="flex" alignItems="center" mt="2px">
                   {/* Checkbox la aprtita IVA è di gruppo */}
@@ -914,6 +887,32 @@ export default function PersonalAndBillingDataSection({
                   </Typography>
                 </Grid>
               )}
+              {(uoSelected || institutionType === 'PA') &&
+                canInvoice &&
+                taxCodeInvoicingVisible && (
+                  <Grid item xs={12} mt={3}>
+                    <CustomTextField
+                      {...baseTextFieldProps(
+                        'taxCodeInvoicing',
+                        t('onboardingFormData.billingDataSection.taxCodeInvoicing'),
+                        600,
+                        theme.palette.text.primary
+                      )}
+                      onChange={(e) => {
+                        formik.setFieldValue('taxCodeInvoicing', e.target.value);
+                        if (e.target.value.length === 11) {
+                          void verifyTaxCodeInvoicing(e.target.value);
+                        } else {
+                          setInvalidTaxCodeInvoicing(false);
+                        }
+                      }}
+                      inputProps={{
+                        maxLength: 11,
+                      }}
+                      disabled={disableTaxCodeInvoicing}
+                    />
+                  </Grid>
+                )}
             </Typography>
           </Grid>
           {isInsuranceCompany && (


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-5344] feat: Show the "Codice Fiscale SFE" field under the "Codice univoco o SDI" field.

#### Motivation and Context

Show the "Codice Fiscale SFE" field under the "Codice univoco o SDI" field.

#### How Has This Been Tested?

Tested that  when a valid sdiCode it's inserted in the sdiCode field, the sfeCode field is shown under the sdiCode field

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5344]: https://pagopa.atlassian.net/browse/SELC-5344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ