### PR TITLE
[SELC-5403] Feat: Add Private Entities radio button on prod-interop

### DIFF
--- a/src/components/__tests__/StepInstitutionType.test.tsx
+++ b/src/components/__tests__/StepInstitutionType.test.tsx
@@ -43,7 +43,7 @@ test('Test: The correct institution types with the expected descriptions, can be
           expect(institutionTypeValues).toStrictEqual(['PA']);
           break;
         case 'prod-interop':
-          expect(institutionTypeValues).toStrictEqual(['PA', 'GSP', 'SCP', 'SA', 'AS']);
+          expect(institutionTypeValues).toStrictEqual(['PA', 'GSP', 'SCP', 'SA', 'AS', 'PRV']);
           break;
         default:
           expect(institutionTypeValues).toStrictEqual(['PA', 'GSP', 'SCP']);

--- a/src/components/autocomplete/components/partyAdvancedSearchType/PartyAdvancedSelect.tsx
+++ b/src/components/autocomplete/components/partyAdvancedSearchType/PartyAdvancedSelect.tsx
@@ -86,7 +86,7 @@ export default function PartyAdvancedSelect({
   };
 
   useEffect(() => {
-    if (product?.id === 'prod-interop' && institutionType === 'SCP') {
+    if (product?.id === 'prod-interop' && (institutionType === 'SCP' || institutionType === 'PRV')) {
       onSelectValue(false, true, false, false, false);
       setTypeOfSearch('taxCode');
     }
@@ -109,7 +109,7 @@ export default function PartyAdvancedSelect({
   }, []);
 
   useEffect(() => {
-    if (addUser || (product?.id === 'prod-interop' && institutionType === 'SCP')) {
+    if (addUser || (product?.id === 'prod-interop' && (institutionType === 'SCP' || institutionType === 'PRV'))) {
       setTypeOfSearch('taxCode');
       setIsTaxCodeSelected(true);
     } else {
@@ -155,7 +155,7 @@ export default function PartyAdvancedSelect({
         label={t('partyAdvancedSelect.advancedSearchLabel')}
         onChange={handleTypeSearchChange}
       >
-        {!addUser && institutionType !== 'SCP' && (
+        {!addUser && institutionType !== 'SCP' && institutionType !== 'PRV' && (
           <MenuItem
             id="businessName"
             data-testid="businessName"
@@ -188,6 +188,7 @@ export default function PartyAdvancedSelect({
         {((ENV.AOO_UO.SHOW_AOO_UO &&
           optionsAvailable4InstitutionType &&
           institutionType !== 'SCP' &&
+          institutionType !== 'PRV' &&
           filteredByProducts(product as Product)) ||
           (addUser && ENV.AOO_UO.SHOW_AOO_UO && filteredByProducts(selectedProduct))) &&
           menuItems.map((item) => (

--- a/src/components/steps/StepSearchParty.tsx
+++ b/src/components/steps/StepSearchParty.tsx
@@ -51,7 +51,7 @@ const handleSearchExternalId = async (
   return null;
 };
 
-// eslint-disable-next-line sonarjs/cognitive-complexity
+// eslint-disable-next-line sonarjs/cognitive-complexity, complexity
 export function StepSearchParty({
   subTitle,
   forward,
@@ -279,7 +279,7 @@ export function StepSearchParty({
                 inserisci uno dei dati richiesti e cerca l’ente per
                 <br /> cui vuoi richiedere l’adesione a <strong>Interoperabilità.</strong>
               </Trans>
-            ) : institutionType === 'SCP' ? (
+            ) : institutionType === 'SCP' || institutionType === 'PRV' ? (
               <Trans
                 i18nKey="onboardingStep1.onboarding.scpSubtitle"
                 components={{ 3: <br />, 5: <strong /> }}
@@ -385,7 +385,7 @@ export function StepSearchParty({
             </Grid>
           )}
       </Grid>
-      {institutionType !== 'SA' && institutionType !== 'AS' && institutionType !== 'SCP' && (
+      {institutionType !== 'SA' && institutionType !== 'AS' && institutionType !== 'SCP' &&  institutionType !== 'PRV' && (
         <Grid container item justifyContent="center">
           <Grid item xs={6}>
             <Box

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -904,6 +904,7 @@ export const institutionTypes: Array<InstitutionType> = [
   'AS',
   'SA',
   'PSP',
+  'PRV'
 ];
 
 export const mockedInsuranceResource: InsuranceCompaniesResource = {

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -591,6 +591,9 @@ export default {
       as: {
         title: 'Società di assicurazione',
       },
+      prv: {
+        title: 'Privati'
+      }
     },
     backLabel: 'Indietro',
     confirmLabel: 'Continua',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -211,6 +211,7 @@ export const institutionTypes: Array<{ labelKey: string; value: InstitutionType 
   { labelKey: 'psp', value: 'PSP' },
   { labelKey: 'sa', value: 'SA' },
   { labelKey: 'as', value: 'AS' },
+  { labelKey: 'prv', value: 'PRV' },
 ];
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
@@ -223,7 +224,8 @@ export const institutionType4Product = (productId: string | undefined) => {
           it.labelKey === 'gsp' ||
           it.labelKey === 'sa' ||
           (ENV.SCP_INFOCAMERE.SHOW && it.labelKey === 'scp') ||
-          it.labelKey === 'as'
+          it.labelKey === 'as' ||
+          it.labelKey === 'prv'
       );
     case 'prod-pn':
       return institutionTypes.filter((it) => it.labelKey === 'pa');
@@ -267,6 +269,7 @@ export const description4InstitutionType = (institutionType: InstitutionType) =>
     case 'PSP':
     case 'SA':
     case 'AS':
+    case 'PRV':
     default:
       return '';
   }

--- a/src/views/onboardingProduct/OnboardingProduct.tsx
+++ b/src/views/onboardingProduct/OnboardingProduct.tsx
@@ -577,7 +577,8 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
       newInstitutionType !== 'PA' &&
       newInstitutionType !== 'SA' &&
       newInstitutionType !== 'AS' &&
-      newInstitutionType !== 'SCP'
+      newInstitutionType !== 'SCP'&&
+      newInstitutionType !== 'PRV'
     ) {
       if (newInstitutionType !== institutionType) {
         setOnboardingFormData({

--- a/types.ts
+++ b/types.ts
@@ -239,7 +239,7 @@ export type InstitutionOnboardingInfoResource = {
   institution: InstitutionData;
 };
 
-export type InstitutionType = 'PA' | 'GSP' | 'SCP' | 'PT' | 'PSP' | 'SA' | 'AS';
+export type InstitutionType = 'PA' | 'GSP' | 'SCP' | 'PT' | 'PSP' | 'SA' | 'AS' | 'PRV';
 
 export type ANACParty = {
   description: string;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-5403] Feat: Add Private Entities radio button on prod-interop

#### Motivation and Context

Added the new feature Private Entities radio button for the product interoperability

#### How Has This Been Tested?

Tested that the new radioButton Privite is in page and updated test StepInstitutionType.test

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.