### PR TITLE
[SELC-4567] fix: avoid to send subunitCode if not present

### DIFF
--- a/src/views/onboardingUser/OnboardingUser.tsx
+++ b/src/views/onboardingUser/OnboardingUser.tsx
@@ -117,9 +117,7 @@ function OnboardingUserComponent() {
           institutionType: onboardingFormData?.institutionType ?? institutionType,
           origin: onboardingFormData?.origin,
           originId: onboardingFormData?.originId,
-          subunitCode: selectedParty?.codiceUniUo
-            ? selectedParty.codiceUniUo
-            : selectedParty?.codiceUniAoo ?? onboardingFormData?.originId,
+          subunitCode: selectedParty?.codiceUniUo ? selectedParty.codiceUniUo : selectedParty?.codiceUniAoo,
           taxCode: onboardingFormData?.taxCode,
           users,
         },
@@ -244,10 +242,10 @@ function OnboardingUserComponent() {
           partyName: selectedParty?.codiceUniAoo
             ? selectedParty.denominazioneAoo
             : selectedParty?.codiceUniUo
-            ? selectedParty.descrizioneUo
-            : selectedParty?.businessName
-            ? selectedParty.businessName
-            : selectedParty?.description ?? '',
+              ? selectedParty.descrizioneUo
+              : selectedParty?.businessName
+                ? selectedParty.businessName
+                : selectedParty?.description ?? '',
           isTechPartner,
           forward: (newFormData: Partial<FormData>) => {
             const users = ((newFormData as any).users as Array<UserOnCreate>).map((u) => ({


### PR DESCRIPTION
…niqueCode nor aooUniqueCode

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-4567] fix: avoid to send subunitCode if not present nor the uoUniqueCode nor the aooUniqueCode

#### Motivation and Context

Avoid to send subunitCode  if not present nor the uoUniqueCode nor the aooUniqueCode, in the request of the API ONBOARDING_NEW_USER

#### How Has This Been Tested?

Tested that if the uoUniqueCode and the aooUniqueCode are not present, the request ONBOARDING_NEW_USER goes succesful and the request for a new user is send.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-4567]: https://pagopa.atlassian.net/browse/SELC-4567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ