### PR TITLE
[SELC-5478] fix: Manually joining a GPS

### DIFF
--- a/src/views/onboardingProduct/OnboardingProduct.tsx
+++ b/src/views/onboardingProduct/OnboardingProduct.tsx
@@ -282,16 +282,20 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
     onboardingData: OnboardingFormData,
     institutionType: InstitutionType
   ) => {
-    setOnboardingFormData(onboardingData);
-    setExternalInstitutionId(onboardingData.externalId ?? '');
-    setOrigin(onboardingData.origin);
-    forwardWithData(onboardingData as Partial<FormData>);
-    trackEvent('ONBOARDING_PARTY_SELECTION', {
-      party_id: onboardingData?.externalId,
-      request_id: requestIdRef.current,
-      product_id: productId,
-    });
-    setInstitutionType(institutionType);
+    if (onboardingData.taxCode !== "") {
+      setOnboardingFormData(onboardingData);
+      setExternalInstitutionId(onboardingData.externalId ?? '');
+      setOrigin(onboardingData.origin);
+      forwardWithData(onboardingData as Partial<FormData>);
+      trackEvent('ONBOARDING_PARTY_SELECTION', {
+        party_id: onboardingData?.externalId,
+        request_id: requestIdRef.current,
+        product_id: productId,
+      });
+      setInstitutionType(institutionType);
+    } else {
+      setActiveStep(activeStep + 3);
+    }
   };
 
   const forwardWithBillingData = (newOnboardingFormData: OnboardingFormData) => {

--- a/src/views/onboardingProduct/OnboardingProduct.tsx
+++ b/src/views/onboardingProduct/OnboardingProduct.tsx
@@ -282,7 +282,9 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
     onboardingData: OnboardingFormData,
     institutionType: InstitutionType
   ) => {
-    if (onboardingData.taxCode !== "") {
+    if (onboardingData.taxCode === "" && onboardingData.originId === "" && institutionType === "GSP") {
+      setActiveStep(activeStep + 3);
+    } else {
       setOnboardingFormData(onboardingData);
       setExternalInstitutionId(onboardingData.externalId ?? '');
       setOrigin(onboardingData.origin);
@@ -293,8 +295,6 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
         product_id: productId,
       });
       setInstitutionType(institutionType);
-    } else {
-      setActiveStep(activeStep + 3);
     }
   };
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-5478] fix: Manually joining a GPS

#### Motivation and Context

When the user click the link "Inserisci manualmente i dati del tuo ente" there is an API invocation that controls if the party were already onboarded, passing as parameter the party taxcode, but in that specific case the taxcode will never exist.

#### How Has This Been Tested?

Tested that when the user click the link "Inserisci manualmente i dati del tuo ente" it brings him in the correct step

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5478]: https://pagopa.atlassian.net/browse/SELC-5478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ