### PR TITLE
[SELC-5496] feat: Updated originId for onboarding flow of SCP and PRV

### DIFF
--- a/src/components/steps/StepSearchParty.tsx
+++ b/src/components/steps/StepSearchParty.tsx
@@ -221,7 +221,7 @@ export function StepSearchParty({
   const onForwardAction = () => {
     const dataParty = aooResult || uoResult ? ({ ...selected, ...ecData } as PartyData) : selected;
     setSelectedHistory(selected);
-    const onboardingData = selected2OnboardingData(dataParty, isAggregator);
+    const onboardingData = selected2OnboardingData(dataParty, isAggregator, institutionType);
     forward(onboardingData, institutionType);
   };
 

--- a/src/utils/selected2OnboardingData.ts
+++ b/src/utils/selected2OnboardingData.ts
@@ -1,10 +1,12 @@
-import { PartyData } from '../../types';
+import { InstitutionType, PartyData } from '../../types';
 import { OnboardingFormData } from '../model/OnboardingFormData';
 
 // eslint-disable-next-line complexity
 export const selected2OnboardingData = (
   selectedParty: PartyData | null,
-  isAggregator?: boolean
+  isAggregator?: boolean,
+  institutionType?: InstitutionType
+// eslint-disable-next-line sonarjs/cognitive-complexity
 ): OnboardingFormData => ({
   businessName:
     selectedParty?.description ??
@@ -30,8 +32,14 @@ export const selected2OnboardingData = (
   zipCode: selectedParty?.CAP ?? selectedParty?.zipCode,
   geographicTaxonomies: [],
   originIdEc: selectedParty?.originId,
-  originId: selectedParty?.codiceUniUo ?? selectedParty?.codiceUniAoo ?? selectedParty?.originId,
-  origin: selectedParty?.origin,
+  originId:
+    institutionType === 'PRV' || institutionType === 'SCP'
+      ? selectedParty?.businessTaxId
+      : selectedParty?.codiceUniUo ?? selectedParty?.codiceUniAoo ?? selectedParty?.originId,
+  origin: 
+    institutionType === 'PRV' || institutionType === 'SCP'
+      ? 'PDND_INFOCAMERE' 
+      : selectedParty?.origin,
   rea:
     selectedParty?.cciaa && selectedParty?.nRea
       ? `${selectedParty?.cciaa}-${selectedParty?.nRea}`

--- a/src/views/onboardingProduct/OnboardingProduct.tsx
+++ b/src/views/onboardingProduct/OnboardingProduct.tsx
@@ -464,12 +464,7 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
             county: onboardingFormData?.county,
             city: onboardingFormData?.city,
           },
-          origin:
-            institutionType === 'SCP' && productId === 'prod-interop'
-              ? 'INFOCAMERE'
-              : institutionType === 'SA'
-              ? 'ANAC'
-              : origin,
+          origin: institutionType === 'SA' ? 'ANAC' : origin,
           users,
           pricingPlan,
           assistanceContacts: onboardingFormData?.supportEmail

--- a/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
+++ b/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
@@ -365,61 +365,11 @@ test('Test: Successfull complete onboarding request of italian AS without tax co
 });
 
 test('Test: Successfull complete onboarding request of SCP for product prod-interop search from infocamere with tax code', async () => {
-  renderComponent('prod-interop');
-  await executeStepInstitutionType('prod-interop', 'SCP');
-  await executeStepSearchParty(
-    'prod-interop',
-    'SCP',
-    'Mocked business 1',
-    'taxCode',
-    undefined,
-    '00112233445',
-    undefined,
-    false,
-    true
-  );
-  await executeStepBillingData(
-    'prod-interop',
-    'SCP',
-    false,
-    false,
-    'PDND_INFOCAMERE',
-    'Mocked business 1',
-    false
-  );
-  await executeStepAddManager();
-  await executeStepAddAdmin(true, false);
-  await verifySubmit('prod-interop', 'SCP', 'PDND_INFOCAMERE', false, false, 'taxCode', false);
-  await executeGoHome(true);
+  await completeOnboardingPdndInfocamereRequest('SCP');
 });
 
 test('Test: Successfull complete onboarding request of PRV for product prod-interop search from infocamere with tax code', async () => {
-  renderComponent('prod-interop');
-  await executeStepInstitutionType('prod-interop', 'PRV');
-  await executeStepSearchParty(
-    'prod-interop',
-    'PRV',
-    'Mocked business 1',
-    'taxCode',
-    undefined,
-    '00112233445',
-    undefined,
-    false,
-    true
-  );
-  await executeStepBillingData(
-    'prod-interop',
-    'PRV',
-    false,
-    false,
-    'PDND_INFOCAMERE',
-    'Mocked business 1',
-    false
-  );
-  await executeStepAddManager();
-  await executeStepAddAdmin(true, false);
-  await verifySubmit('prod-interop', 'PRV', 'PDND_INFOCAMERE', false, false, 'taxCode', false);
-  await executeGoHome(true);
+  await completeOnboardingPdndInfocamereRequest('PRV');
 });
 
 test('Test: Successfull complete onboarding request of PA aggregator party for prod-io search by business name', async () => {
@@ -565,6 +515,35 @@ test('Test: RecipientCode input client validation', async () => {
   fireEvent.input(recipientCodeInput, { target: { value: 'AB123CD' } });
   expect(recipientCodeInput.value).toBe('AB123CD');
 });
+
+const completeOnboardingPdndInfocamereRequest = async (institutionType) => {
+  renderComponent('prod-interop');
+  await executeStepInstitutionType('prod-interop', institutionType);
+  await executeStepSearchParty(
+    'prod-interop',
+    institutionType,
+    'Mocked business 1',
+    'taxCode',
+    undefined,
+    '00112233445',
+    undefined,
+    false,
+    true
+  );
+  await executeStepBillingData(
+    'prod-interop',
+    institutionType,
+    false,
+    false,
+    'PDND_INFOCAMERE',
+    'Mocked business 1',
+    false
+  );
+  await executeStepAddManager();
+  await executeStepAddAdmin(true, false);
+  await verifySubmit('prod-interop', institutionType, 'PDND_INFOCAMERE', false, false, 'taxCode', false);
+  await executeGoHome(true);
+};
 
 const performLogout = async (logoutButton: HTMLElement) => {
   fireEvent.click(logoutButton);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-5496] feat: Updated originId for onboarding flow of SCP and PRV

#### Motivation and Context

In the onboarding request flow of SCP and PRV the of institution types of SCP and PRV makes their request to the infocamere resocurces, and they needed a different value type for the fields originId and origin.

#### How Has This Been Tested?

Tested that in the onboarding request flow of SCP and PRV the field origin and originId have the correct value and that the request goes succesful, and updated and added junit tests.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5496]: https://pagopa.atlassian.net/browse/SELC-5496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ