### PR TITLE
[SELC-5491] feat: Added RadioButton "Altro" for Private Entities

### DIFF
--- a/src/components/__tests__/StepInstitutionType.test.tsx
+++ b/src/components/__tests__/StepInstitutionType.test.tsx
@@ -30,7 +30,7 @@ test('Test: The correct institution types with the expected descriptions, can be
 
       switch (p.id) {
         case 'prod-pagopa':
-          expect(institutionTypeValues).toStrictEqual(['PA', 'GSP', 'PT', 'PSP']);
+          expect(institutionTypeValues).toStrictEqual(['PA', 'GSP', 'PT', 'PSP', 'PRV']);
           break;
         case 'prod-io':
           expect(institutionTypeValues).toStrictEqual(['PA', 'GSP', 'PT']);

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -594,7 +594,7 @@ export default {
       prv: {
         title: 'Privati'
       },
-      pprv: {
+      oth: {
         title: 'Altro'
       }
     },

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -593,6 +593,9 @@ export default {
       },
       prv: {
         title: 'Privati'
+      },
+      pprv: {
+        title: 'Altro'
       }
     },
     backLabel: 'Indietro',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -180,8 +180,8 @@ export const filterByCategory = (institutionType?: string, productId?: string) =
   productId === 'prod-pn'
     ? 'L6,L4,L45,L35,L5,L17,L15,C14'
     : institutionType === 'GSP'
-    ? 'L37,SAG'
-    : 'C17,C16,L10,L19,L13,L2,C10,L20,L21,L22,L15,L1,C13,C5,L40,L11,L39,L46,L8,L34,L7,L35,L45,L47,L6,L12,L24,L28,L42,L36,L44,C8,C3,C7,C14,L16,C11,L33,C12,L43,C2,L38,C1,L5,L4,L31,L18,L17,S01,SA';
+      ? 'L37,SAG'
+      : 'C17,C16,L10,L19,L13,L2,C10,L20,L21,L22,L15,L1,C13,C5,L40,L11,L39,L46,L8,L34,L7,L35,L45,L47,L6,L12,L24,L28,L42,L36,L44,C8,C3,C7,C14,L16,C11,L33,C12,L43,C2,L38,C1,L5,L4,L31,L18,L17,S01,SA';
 
 export const canInvoice = (institutionType?: string, productId?: string) =>
   institutionType !== 'SA' &&
@@ -212,7 +212,9 @@ export const institutionTypes: Array<{ labelKey: string; value: InstitutionType 
   { labelKey: 'sa', value: 'SA' },
   { labelKey: 'as', value: 'AS' },
   { labelKey: 'prv', value: 'PRV' },
-  { labelKey: 'pprv', value: 'PRV' },
+  /* both are private entities but for two different products:
+    prv -> "Enti Privati" (prod-interop), oth -> "Altro" (prod-pagopa) */
+  { labelKey: 'oth', value: 'PRV' },
 ];
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
@@ -247,7 +249,7 @@ export const institutionType4Product = (productId: string | undefined) => {
           it.labelKey === 'gsp' ||
           (ENV.ENV !== 'PROD' && it.labelKey === 'psp') ||
           (ENV.PT.SHOW_PT ? it.labelKey === 'pt' : '') ||
-          it.labelKey === 'pprv'
+          it.labelKey === 'oth'
       );
     case 'prod-io-sign':
       return institutionTypes.filter((it) => it.labelKey === 'pa' || it.labelKey === 'gsp');

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -212,6 +212,7 @@ export const institutionTypes: Array<{ labelKey: string; value: InstitutionType 
   { labelKey: 'sa', value: 'SA' },
   { labelKey: 'as', value: 'AS' },
   { labelKey: 'prv', value: 'PRV' },
+  { labelKey: 'pprv', value: 'PRV' },
 ];
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
@@ -245,7 +246,8 @@ export const institutionType4Product = (productId: string | undefined) => {
           it.labelKey === 'pa' ||
           it.labelKey === 'gsp' ||
           (ENV.ENV !== 'PROD' && it.labelKey === 'psp') ||
-          (ENV.PT.SHOW_PT ? it.labelKey === 'pt' : '')
+          (ENV.PT.SHOW_PT ? it.labelKey === 'pt' : '') ||
+          it.labelKey === 'pprv'
       );
     case 'prod-io-sign':
       return institutionTypes.filter((it) => it.labelKey === 'pa' || it.labelKey === 'gsp');


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-5491] feat: Added RadioButton "Altro" for Private Entities

#### Motivation and Context

With the new radioButton "Altro" now the users can access to a new onboarding flow for the Private Entities for the product "Piattaforma pagoPA"

#### How Has This Been Tested?

Tested that in the selection page of the institution type there is the new radioButton "Altro".
Tested with unit test.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5491]: https://pagopa.atlassian.net/browse/SELC-5491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ