### PR TITLE
[SELC-5492] feat: Connection with empty data entry form

### DIFF
--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -110,7 +110,7 @@ export default function PersonalAndBillingDataSection({
   const [nationalCountries, setNationalCountries] = useState<Array<CountryResource>>();
   const [input, setInput] = useState<string>();
   const [disableTaxCodeInvoicing, setDisableTaxCodeInvoicing] = useState<boolean>(false);
-  const [taxCodeInvoicingVisible, setTaxCodeInovoicingVisible] = useState<boolean>(false);
+  const [taxCodeInvoicingVisible, setTaxCodeInvoicingVisible] = useState<boolean>(false);
 
   useEffect(() => {
     const shareCapitalIsNan = isNaN(formik.values.shareCapital);
@@ -125,7 +125,7 @@ export default function PersonalAndBillingDataSection({
   }, [formik.values.shareCapital]);
 
   useEffect(() => {
-    if (institutionLocationData && institutionLocationData.city) {
+    if (institutionLocationData?.city) {
       formik.setFieldValue('country', institutionLocationData.country);
       formik.setFieldValue('county', institutionLocationData.county);
       formik.setFieldValue('city', institutionLocationData.city);
@@ -146,7 +146,7 @@ export default function PersonalAndBillingDataSection({
   const isPaymentServiceProvider = institutionType === 'PSP';
   const isContractingAuthority = institutionType === 'SA';
   const isInsuranceCompany = institutionType === 'AS';
-  const isAooUo = !!(onboardingFormData?.uoUniqueCode || onboardingFormData?.aooUniqueCode);
+  const isAooUo = !!(onboardingFormData?.uoUniqueCode ?? onboardingFormData?.aooUniqueCode);
 
   useEffect(() => {
     if (!isPremium && (isFromIPA || isAooUo)) {
@@ -177,11 +177,11 @@ export default function PersonalAndBillingDataSection({
   useEffect(() => {
     if (formik.values.recipientCode?.length >= 6 && recipientCodeStatus === 'ACCEPTED') {
       void getUoInfoFromRecipientCode(formik.values.recipientCode);
-      setTaxCodeInovoicingVisible(true);
+      setTaxCodeInvoicingVisible(true);
     } else {
       formik.setFieldValue('taxCodeInovoicing', undefined);
       setDisableTaxCodeInvoicing(false);
-      setTaxCodeInovoicingVisible(false);
+      setTaxCodeInvoicingVisible(false);
     }
   }, [formik.values.recipientCode, recipientCodeStatus]);
 
@@ -434,7 +434,7 @@ export default function PersonalAndBillingDataSection({
                 isContractingAuthority ||
                 isInsuranceCompany ||
                 (isInformationCompany && onboardingFormData?.businessName) ||
-                institutionType === 'PRV'
+                (institutionType === 'PRV' && productId !== 'prod-pagopa')
               }
             />
           </Grid>
@@ -442,7 +442,7 @@ export default function PersonalAndBillingDataSection({
         <Grid container spacing={2} pl={3} pt={3}>
           <Grid item xs={isForeignInsurance ? 12 : 7}>
             <CustomTextFieldNotched
-              paddingValue='20px'
+              paddingValue="20px"
               {...baseTextFieldProps(
                 'registeredOffice',
                 t('onboardingFormData.billingDataSection.fullLegalAddress'),
@@ -519,7 +519,7 @@ export default function PersonalAndBillingDataSection({
                 options={countries ?? []}
                 noOptionsText={t('onboardingFormData.billingDataSection.noResult')}
                 clearOnBlur={true}
-                forcePopupIcon={isFromIPA || !isCityEditable ? false : true}
+                forcePopupIcon={!(isFromIPA || !isCityEditable)}
                 disabled={isPremium && isCityEditable ? false : isFromIPA || isAooUo}
                 ListboxProps={{
                   style: {
@@ -696,34 +696,34 @@ export default function PersonalAndBillingDataSection({
               isContractingAuthority ||
               isInsuranceCompany ||
               (isInformationCompany && onboardingFormData?.digitalAddress) ||
-              institutionType === 'PRV'
+              (institutionType === 'PRV' && productId !== 'prod-pagopa')
             }
           />
         </Grid>
         {(!isInsuranceCompany ||
           (onboardingFormData?.taxCode && onboardingFormData?.taxCode !== '')) && (
-            <Grid item xs={12}>
-              <CustomTextField
-                {...baseTextFieldProps(
-                  'taxCode',
-                  isAooUo
-                    ? t('onboardingFormData.billingDataSection.taxCodeCentralParty')
-                    : t('onboardingFormData.billingDataSection.taxCode'),
-                  600,
-                  isDisabled || isContractingAuthority || isInsuranceCompany
-                    ? theme.palette.text.disabled
-                    : theme.palette.text.primary
-                )}
-                disabled={
-                  isDisabled ||
-                  isContractingAuthority ||
-                  isInsuranceCompany ||
-                  (isInformationCompany && onboardingFormData?.taxCode) ||
-                  institutionType === 'PRV'
-                }
-              />
-            </Grid>
-          )}
+          <Grid item xs={12}>
+            <CustomTextField
+              {...baseTextFieldProps(
+                'taxCode',
+                isAooUo
+                  ? t('onboardingFormData.billingDataSection.taxCodeCentralParty')
+                  : t('onboardingFormData.billingDataSection.taxCode'),
+                600,
+                isDisabled || isContractingAuthority || isInsuranceCompany
+                  ? theme.palette.text.disabled
+                  : theme.palette.text.primary
+              )}
+              disabled={
+                isDisabled ||
+                isContractingAuthority ||
+                isInsuranceCompany ||
+                (isInformationCompany && onboardingFormData?.taxCode) ||
+                (institutionType === 'PRV' && productId !== 'prod-pagopa')
+              }
+            />
+          </Grid>
+        )}
 
         {!isForeignInsurance && (
           <Grid
@@ -935,68 +935,69 @@ export default function PersonalAndBillingDataSection({
         )}
         {(isInformationCompany ||
           isContractingAuthority ||
-          (productId === 'prod-interop' &&
+          ((productId === 'prod-interop' || productId === 'prod-pagopa') &&
             (institutionType === 'SCP' || institutionType === 'PRV'))) && (
             <>
               <Grid item xs={12}>
                 {/* Luogo di iscrizione al Registro delle Imprese facoltativo per institution Type !== 'PA' e 'PSP */}
                 <CustomTextFieldNotched
                 paddingValue={isContractingAuthority ? '20px' : '24px'}
-                  {...baseTextFieldProps(
-                    'businessRegisterPlace',
-                    isContractingAuthority
-                      ? t(
+                {...baseTextFieldProps(
+                  'businessRegisterPlace',
+                  isContractingAuthority ||
+                    (institutionType === 'PRV' && productId === 'prod-pagopa')
+                    ? t(
                         'onboardingFormData.billingDataSection.informationCompanies.requiredCommercialRegisterNumber'
                       )
-                      : t(
+                    : t(
                         'onboardingFormData.billingDataSection.informationCompanies.commercialRegisterNumber'
                       ),
-                    600,
-                    theme.palette.text.primary
-                  )}
-                />
-              </Grid>
-              <Grid item xs={6}>
-                <CustomTextField
-                  placeholder={'RM-123456'}
-                  {...baseTextFieldProps(
-                    'rea',
-                    t('onboardingFormData.billingDataSection.informationCompanies.rea'),
-                    600,
-                    theme.palette.text.primary
-                  )}
-                />
-              </Grid>
-              <Grid item xs={6}>
-                {/* capitale sociale facoltativo per institution Type !== 'PA' e 'PSP */}
-                <CustomTextField
-                  name={'shareCapital'}
-                  {...baseTextFieldProps(
-                    'shareCapital',
-                    isContractingAuthority
-                      ? t(
+                  600,
+                  theme.palette.text.primary
+                )}
+              />
+            </Grid>
+            <Grid item xs={6}>
+              <CustomTextField
+                placeholder={'RM-123456'}
+                {...baseTextFieldProps(
+                  'rea',
+                  institutionType === 'PRV' && productId === 'prod-pagopa'
+                    ? t('onboardingFormData.billingDataSection.informationCompanies.rea')
+                    : t('onboardingFormData.billingDataSection.informationCompanies.requiredRea'),
+                  600,
+                  theme.palette.text.primary
+                )}
+              />
+            </Grid>
+            <Grid item xs={6}>
+              {/* capitale sociale facoltativo per institution Type !== 'PA' e 'PSP */}
+              <CustomTextField
+                name={'shareCapital'}
+                {...baseTextFieldProps(
+                  'shareCapital',
+                  isContractingAuthority
+                    ? t(
                         'onboardingFormData.billingDataSection.informationCompanies.requiredShareCapital'
                       )
-                      : t(
-                        'onboardingFormData.billingDataSection.informationCompanies.shareCapital'
-                      ),
-                    600,
-                    theme.palette.text.primary
-                  )}
-                  onClick={() => setShrinkRea(true)}
-                  onBlur={() => {
-                    if (!formik.values.shareCapital) {
-                      setShrinkRea(false);
-                    }
-                  }}
-                  InputLabelProps={{ shrink: shrinkRea }}
-                  InputProps={{
-                    inputComponent: NumberDecimalFormat,
-                  }}
-                />
-              </Grid>
-            </>
-          )}
+                    : t('onboardingFormData.billingDataSection.informationCompanies.shareCapital'),
+                  600,
+                  theme.palette.text.primary
+                )}
+                onClick={() => setShrinkRea(true)}
+                onBlur={() => {
+                  if (!formik.values.shareCapital) {
+                    setShrinkRea(false);
+                  }
+                }}
+                InputLabelProps={{ shrink: shrinkRea }}
+                InputProps={{
+                  inputComponent: NumberDecimalFormat,
+                }}
+              />
+            </Grid>
+          </>
+        )}
         {isPaymentServiceProvider && (
           <>
             <Grid item xs={12}>
@@ -1018,9 +1019,7 @@ export default function PersonalAndBillingDataSection({
               <CustomTextField
                 {...baseTextFieldProps(
                   'registrationInRegister',
-                  t(
-                    'onboardingFormData.billingDataSection.pspDataSection.registrationInRegister'
-                  ),
+                  t('onboardingFormData.billingDataSection.pspDataSection.registrationInRegister'),
                   600,
                   theme.palette.text.primary
                 )}

--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -114,6 +114,7 @@ export default function StepOnboardingFormData({
 
   const isInformationCompany =
     origin !== 'IPA' &&
+    institutionType !== 'PRV' &&
     (institutionType === 'GSP' || institutionType === 'SCP') &&
     (productId === 'prod-io' ||
       productId === 'prod-io-sign' ||
@@ -296,9 +297,11 @@ export default function StepOnboardingFormData({
 
   useEffect(() => {
     if (formik.values.hasVatnumber) {
-      void formik.setFieldValue('vatNumber', formik.initialValues.vatNumber);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      formik.setFieldValue('vatNumber', formik.initialValues.vatNumber);
     } else {
-      void formik.setFieldValue('vatNumber', undefined);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      formik.setFieldValue('vatNumber', undefined);
     }
   }, [formik.values.hasVatnumber]);
 
@@ -355,7 +358,8 @@ export default function StepOnboardingFormData({
     if (outcome === 'success') {
       const result = (getRecipientCodeValidation as AxiosResponse).data;
       if (uoSelected && result && result === 'DENIED_NO_BILLING') {
-        void formik.setFieldValue('recipientCode', undefined);
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        formik.setFieldValue('recipientCode', undefined);
       }
       setRecipientCodeStatus(result);
     } else {
@@ -407,8 +411,8 @@ export default function StepOnboardingFormData({
   const baseTextFieldProps = (
     field: keyof OnboardingFormData,
     label: string,
+    color: string,
     fontWeight: string | number = isDisabled ? 'fontWeightRegular' : 'fontWeightMedium',
-    color: string
   ) => {
     const isError = !!formik.errors[field] && formik.errors[field] !== requiredError;
     return {

--- a/src/components/steps/StepSearchParty.tsx
+++ b/src/components/steps/StepSearchParty.tsx
@@ -221,7 +221,7 @@ export function StepSearchParty({
   const onForwardAction = () => {
     const dataParty = aooResult || uoResult ? ({ ...selected, ...ecData } as PartyData) : selected;
     setSelectedHistory(selected);
-    const onboardingData = selected2OnboardingData(dataParty, isAggregator, institutionType);
+    const onboardingData = selected2OnboardingData(dataParty, isAggregator, institutionType, product?.id);
     forward(onboardingData, institutionType);
   };
 

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -668,7 +668,8 @@ export default {
       },
       informationCompanies: {
         commercialRegisterNumber: 'Luogo di iscrizione al Registro delle Imprese (facoltativo)',
-        rea: 'REA',
+        requiredRea: 'REA',
+        rea: 'REA (facoltativo)',
         shareCapital: 'Capitale sociale (facoltativo)',
         requiredCommercialRegisterNumber: 'Luogo di iscrizione al Registro delle Imprese',
         requiredShareCapital: 'Capitale sociale',

--- a/src/utils/selected2OnboardingData.ts
+++ b/src/utils/selected2OnboardingData.ts
@@ -5,8 +5,9 @@ import { OnboardingFormData } from '../model/OnboardingFormData';
 export const selected2OnboardingData = (
   selectedParty: PartyData | null,
   isAggregator?: boolean,
-  institutionType?: InstitutionType
-// eslint-disable-next-line sonarjs/cognitive-complexity
+  institutionType?: InstitutionType,
+  productId?: string
+  // eslint-disable-next-line sonarjs/cognitive-complexity
 ): OnboardingFormData => ({
   businessName:
     selectedParty?.description ??
@@ -33,12 +34,12 @@ export const selected2OnboardingData = (
   geographicTaxonomies: [],
   originIdEc: selectedParty?.originId,
   originId:
-    institutionType === 'PRV' || institutionType === 'SCP'
+    institutionType === 'PRV' && productId === 'prod-interop' || institutionType === 'SCP'
       ? selectedParty?.businessTaxId
       : selectedParty?.codiceUniUo ?? selectedParty?.codiceUniAoo ?? selectedParty?.originId,
-  origin: 
-    institutionType === 'PRV' || institutionType === 'SCP'
-      ? 'PDND_INFOCAMERE' 
+  origin:
+    institutionType === 'PRV' && productId === 'prod-interop' || institutionType === 'SCP'
+      ? 'PDND_INFOCAMERE'
       : selectedParty?.origin,
   rea:
     selectedParty?.cciaa && selectedParty?.nRea

--- a/src/utils/validateFields.ts
+++ b/src/utils/validateFields.ts
@@ -94,7 +94,10 @@ export const validateFields = (
         ? t('onboardingFormData.billingDataSection.pspDataSection.invalidCommercialRegisterNumber')
         : undefined,
     businessRegisterPlace:
-      institutionType === 'SA' && !values.businessRegisterPlace ? requiredError : undefined,
+      (institutionType === 'SA' || (institutionType === 'PRV' && productId === 'prod-pagopa')) &&
+      !values.businessRegisterPlace
+        ? requiredError
+        : undefined,
     registrationInRegister:
       isPaymentServiceProvider && !values.registrationInRegister ? requiredError : undefined,
     dpoAddress: isPaymentServiceProvider && !values.dpoAddress ? requiredError : undefined,

--- a/src/views/onboardingProduct/OnboardingProduct.tsx
+++ b/src/views/onboardingProduct/OnboardingProduct.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useContext, useRef, useMemo } from 'react';
+import React, { useEffect, useState, useContext, useRef, useMemo }  from 'react';
 import { useHistory } from 'react-router-dom';
 import { Container } from '@mui/material';
 import { AxiosError, AxiosResponse } from 'axios';
@@ -8,7 +8,6 @@ import { useTranslation, Trans } from 'react-i18next';
 import { uniqueId } from 'lodash';
 import { IllusCompleted, IllusError } from '@pagopa/mui-italia';
 import { EndingPage } from '@pagopa/selfcare-common-frontend/lib';
-import React from 'react';
 import { withLogin } from '../../components/withLogin';
 import {
   InstitutionType,
@@ -40,6 +39,7 @@ import UserNotAllowedPage from '../UserNotAllowedPage';
 import { AdditionalData, AdditionalInformations } from '../../model/AdditionalInformations';
 import AlreadyOnboarded from '../AlreadyOnboarded';
 import { AggregateInstitution } from '../../model/AggregateInstitution';
+import { selected2OnboardingData } from '../../utils/selected2OnboardingData';
 import { genericError, StepVerifyOnboarding } from './components/StepVerifyOnboarding';
 import { StepAddAdmin } from './components/StepAddAdmin';
 import { StepAdditionalInformations } from './components/StepAdditionalInformations';
@@ -426,18 +426,18 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
           additionalInformations:
             institutionType === 'GSP' && selectedProduct?.id === 'prod-pagopa'
               ? {
-                  agentOfPublicService: additionalInformations?.agentOfPublicService,
-                  agentOfPublicServiceNote: additionalInformations?.agentOfPublicServiceNote,
-                  belongRegulatedMarket: additionalInformations?.belongRegulatedMarket,
-                  regulatedMarketNote: additionalInformations?.regulatedMarketNote,
-                  establishedByRegulatoryProvision:
-                    additionalInformations?.establishedByRegulatoryProvision,
-                  establishedByRegulatoryProvisionNote:
-                    additionalInformations?.establishedByRegulatoryProvisionNote,
-                  ipa: additionalInformations?.ipa,
-                  ipaCode: additionalInformations?.ipaCode,
-                  otherNote: additionalInformations?.otherNote,
-                }
+                agentOfPublicService: additionalInformations?.agentOfPublicService,
+                agentOfPublicServiceNote: additionalInformations?.agentOfPublicServiceNote,
+                belongRegulatedMarket: additionalInformations?.belongRegulatedMarket,
+                regulatedMarketNote: additionalInformations?.regulatedMarketNote,
+                establishedByRegulatoryProvision:
+                  additionalInformations?.establishedByRegulatoryProvision,
+                establishedByRegulatoryProvisionNote:
+                  additionalInformations?.establishedByRegulatoryProvisionNote,
+                ipa: additionalInformations?.ipa,
+                ipaCode: additionalInformations?.ipaCode,
+                otherNote: additionalInformations?.otherNote,
+              }
               : undefined,
           pspData:
             institutionType === 'PSP'
@@ -445,20 +445,20 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
               : undefined,
           companyInformations:
             onboardingFormData?.businessRegisterPlace ||
-            onboardingFormData?.rea ||
-            onboardingFormData?.shareCapital
+              onboardingFormData?.rea ||
+              onboardingFormData?.shareCapital
               ? {
-                  businessRegisterPlace: onboardingFormData?.businessRegisterPlace,
-                  rea: onboardingFormData?.rea,
-                  shareCapital: onboardingFormData?.shareCapital,
-                }
+                businessRegisterPlace: onboardingFormData?.businessRegisterPlace,
+                rea: onboardingFormData?.rea,
+                shareCapital: onboardingFormData?.shareCapital,
+              }
               : undefined,
           institutionType,
           originId: onboardingFormData?.originId,
           geographicTaxonomies: ENV.GEOTAXONOMY.SHOW_GEOTAXONOMY
             ? onboardingFormData?.geographicTaxonomies?.map((gt) =>
-                onboardedInstitutionInfo2geographicTaxonomy(gt)
-              )
+              onboardedInstitutionInfo2geographicTaxonomy(gt)
+            )
             : [],
           institutionLocationData: {
             country:
@@ -479,8 +479,8 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
           subunitType: onboardingFormData?.uoUniqueCode
             ? 'UO'
             : onboardingFormData?.aooUniqueCode
-            ? 'AOO'
-            : undefined,
+              ? 'AOO'
+              : undefined,
           taxCode: onboardingFormData?.taxCode,
           isAggregator: onboardingFormData?.isAggregator
             ? onboardingFormData?.isAggregator
@@ -570,13 +570,21 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
       product_id: productId,
     });
     setInstitutionType(newInstitutionType);
-    forward();
+
+    if (newInstitutionType === 'PRV' && productId === 'prod-pagopa') {
+      selected2OnboardingData(null, undefined, newInstitutionType, productId);
+      setOnboardingFormData(selected2OnboardingData(null, undefined, newInstitutionType, productId));
+      setActiveStep(4);
+    } else {
+      forward();
+    }
+
     if (
       newInstitutionType !== 'GSP' &&
       newInstitutionType !== 'PA' &&
       newInstitutionType !== 'SA' &&
       newInstitutionType !== 'AS' &&
-      newInstitutionType !== 'SCP'&&
+      newInstitutionType !== 'SCP' &&
       newInstitutionType !== 'PRV'
     ) {
       if (newInstitutionType !== institutionType) {

--- a/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
+++ b/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
@@ -395,6 +395,34 @@ test('Test: Successfull complete onboarding request of PA aggregator party for p
   await executeGoHome(true);
 });
 
+test('Test: Successfull complete onboarding request of PRV for product prod-pagopa skipping step search party', async () => {
+  renderComponent('prod-pagopa');
+  await executeStepInstitutionType('prod-pagopa', 'oth');
+  await executeStepBillingData(
+    'prod-pagopa',
+    'PRV',
+    false,
+    false,
+    undefined,
+    'Mocked private 1',
+    false
+  );
+  await executeStepAddManager();
+  await executeStepAddAdmin(true, false);
+  await verifySubmit(
+    'prod-pagopa',
+    'PRV',
+    undefined,
+    false,
+    false,
+    undefined,
+    false,
+    undefined,
+    undefined
+  );
+  await executeGoHome(true);
+});
+
 test('Test: Error on submit onboarding request of PA party for prod-io search by business name', async () => {
   renderComponent('prod-io');
   await executeStepInstitutionType('prod-io', 'PA');
@@ -541,7 +569,15 @@ const completeOnboardingPdndInfocamereRequest = async (institutionType) => {
   );
   await executeStepAddManager();
   await executeStepAddAdmin(true, false);
-  await verifySubmit('prod-interop', institutionType, 'PDND_INFOCAMERE', false, false, 'taxCode', false);
+  await verifySubmit(
+    'prod-interop',
+    institutionType,
+    'PDND_INFOCAMERE',
+    false,
+    false,
+    'taxCode',
+    false
+  );
   await executeGoHome(true);
 };
 
@@ -641,7 +677,7 @@ const executeStepSearchParty = async (
     expect(withoutIpaLink).not.toBeInTheDocument();
   }
 
-  const aggregatorCheckbox = screen.queryByLabelText('Sono un ente aggregatore');
+  const aggregatorCheckbox = screen.queryByLabelText('Sono un ente aggregatore') as HTMLElement;
 
   if (productId === 'prod-io') {
     expect(aggregatorCheckbox).toBeInTheDocument();
@@ -804,6 +840,7 @@ const executeStepBillingData = async (
   await waitFor(() => screen.getByText('Inserisci i dati dell’ente'));
 
   await fillUserBillingDataForm(
+    productId,
     'businessName',
     'registeredOffice',
     'digitalAddress',
@@ -1152,6 +1189,7 @@ const fillInstitutionTypeCheckbox = async (element: string) => {
 };
 
 const fillUserBillingDataForm = async (
+  productId: string,
   businessNameInput: string,
   registeredOfficeInput: string,
   mailPECInput: string,
@@ -1197,7 +1235,9 @@ const fillUserBillingDataForm = async (
     const input = isForeignInsurance ? 'Spa' : 'Mil';
     const expectedOption = isForeignInsurance ? 'Spagna' : 'Milano';
 
-    const autocomplete = document.getElementById((isForeignInsurance ? country : city) as string);
+    const autocomplete = document.getElementById(
+      (isForeignInsurance ? country : city) as string
+    ) as HTMLElement;
     userEvent.type(autocomplete, input);
 
     const option = await screen.findByText(expectedOption, {}, { timeout: 8000 });
@@ -1208,7 +1248,7 @@ const fillUserBillingDataForm = async (
       fireEvent.change(document.getElementById(zipCode) as HTMLElement, {
         target: { value: '09010' },
       });
-      expect(document.getElementById(county) as HTMLElement).toHaveValue('MI');
+      expect(document.getElementById(county ?? '') as HTMLElement).toHaveValue('MI');
     } else {
       fireEvent.change(document.getElementById('city') as HTMLElement, {
         target: { value: 'Valencia' },
@@ -1216,11 +1256,51 @@ const fillUserBillingDataForm = async (
     }
 
     if (institutionType !== 'PT' && institutionType !== 'AS' && institutionType !== 'PSP') {
-      fireEvent.change(document.getElementById(rea) as HTMLInputElement, {
+      fireEvent.change(document.getElementById(rea ?? '') as HTMLInputElement, {
         target: { value: 'MI-12345' },
       });
     }
   } else {
+    if (institutionType === 'PRV' && productId === 'prod-pagopa') {
+      fireEvent.change(document.getElementById(businessNameInput) as HTMLElement, {
+        target: { value: mockPartyRegistry.items[0].description },
+      });
+      fireEvent.change(document.getElementById(mailPECInput) as HTMLElement, {
+        target: { value: mockPartyRegistry.items[0].digitalAddress },
+      });
+
+      fireEvent.change(document.getElementById(zipCode) as HTMLElement, {
+        target: { value: mockPartyRegistry.items[0].zipCode },
+      });
+
+      const autocomplete = document.getElementById(
+        (isForeignInsurance ? country : city) as string
+      ) as HTMLElement;
+      userEvent.type(autocomplete, 'Mil');
+
+      const option = await screen.findByText('Milano', {}, { timeout: 8000 });
+      expect(option).toBeInTheDocument();
+      fireEvent.click(option);
+
+      expect(document.getElementById(county ?? '') as HTMLElement).toHaveValue('MI');
+
+      fireEvent.change(document.getElementById('registeredOffice') as HTMLInputElement, {
+        target: { value: mockPartyRegistry.items[0].address },
+      });
+
+      fireEvent.change(document.getElementById(taxCodeInput) as HTMLElement, {
+        target: { value: mockPartyRegistry.items[0].taxCode },
+      });
+
+      fireEvent.change(document.getElementById(recipientCode) as HTMLElement, {
+        target: { value: 'A1B2C3D' },
+      });
+
+      fireEvent.change(document.getElementById('businessRegisterPlace') as HTMLElement, {
+        target: { value: '01234567891' },
+      });
+    }
+
     const isTaxCodeEquals2PIVA = document.getElementById('taxCodeEquals2VatNumber') as HTMLElement;
     fireEvent.click(isTaxCodeEquals2PIVA);
 
@@ -1321,7 +1401,7 @@ const fillUserBillingDataForm = async (
     fireEvent.change(document.getElementById(recipientCode) as HTMLElement, {
       target: { value: 'A1B2C3D' },
     });
-    fireEvent.change(document.getElementById(supportEmail) as HTMLInputElement, {
+    fireEvent.change(document.getElementById(supportEmail ?? '') as HTMLInputElement, {
       target: { value: 'a@a.it' },
     });
   }
@@ -1515,7 +1595,7 @@ const checkCorrectBodyBillingData = (
 
   if (institutionType === 'SA') {
     fireEvent.change(document.getElementById('businessRegisterPlace') as HTMLElement, {
-      target: { value: 'business register place' },
+      target: { value: '01234567891' },
     });
     fireEvent.change(document.getElementById('rea') as HTMLElement, {
       target: { value: 'MI-12345' },
@@ -1633,7 +1713,7 @@ const fillAdditionalUserAndCheckUniqueValues = async (
   const removeUserButtons = await addAdditionEmptyUser(index, confirmButton);
 
   const prefix = getByLabelText(
-    searchUserFormFromRemoveBtn(removeUserButtons[index]),
+    searchUserFormFromRemoveBtn(removeUserButtons[index]) as HTMLElement,
     'Nome'
   ).id.replace(/-name$/, '');
 
@@ -1817,7 +1897,7 @@ const billingData2billingDataRequest = (
 const verifySubmit = async (
   productId: string = 'prod-io',
   institutionType: string,
-  from: Source = 'IPA',
+  from?: Source,
   uo: boolean = false,
   errorOnSubmit: boolean = false,
   typeOfSearch: Search = 'businessName',
@@ -1878,6 +1958,8 @@ const verifySubmit = async (
             ? mockedAoos[0].codiceUniAoo
             : typeOfSearch === 'uoCode'
             ? mockedUos[0].codiceUniUo
+            : institutionType === 'PRV' && productId === 'prod-pagopa'
+            ? undefined
             : '991',
           taxCode: errorOnSubmit
             ? mockPartyRegistry.items[1].taxCode
@@ -1915,13 +1997,17 @@ const verifySubmit = async (
                 }
               : undefined,
           companyInformations:
-            (from === 'ANAC' ||
+            ((from === 'ANAC' ||
               from === 'INFOCAMERE' ||
               from === 'PDND_INFOCAMERE' ||
               (institutionType === 'GSP' && from !== 'IPA')) &&
-            institutionType !== 'PT'
+              institutionType !== 'PT') ||
+            (institutionType === 'PRV' && productId === 'prod-pagopa')
               ? {
-                  businessRegisterPlace: from === 'ANAC' ? 'business register place' : undefined,
+                  businessRegisterPlace:
+                    from === 'ANAC' || (institutionType === 'PRV' && productId === 'prod-pagopa')
+                      ? '01234567891'
+                      : undefined,
                   shareCapital: from === 'ANAC' ? 332323 : undefined,
                   rea:
                     from === 'INFOCAMERE' || from === 'PDND_INFOCAMERE'
@@ -1929,6 +2015,8 @@ const verifySubmit = async (
                           '-',
                           mockedPartiesFromInfoCamere[0].nRea
                         )
+                      : institutionType === 'PRV' && productId === 'prod-pagopa'
+                      ? undefined
                       : 'MI-12345',
                 }
               : undefined,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-5492] feat: Connection with empty data entry form

#### Motivation and Context

When the user choice the institutionType "Altro" in first step is redirect directly to the form billing data skipping the step search party. when it land in the step billing data it will be all empty and with the data to be setted.

#### How Has This Been Tested?

Tested that the onboarding flow for the institution type "Altro" works and send the data as expected.
Tested with unit test.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5492]: https://pagopa.atlassian.net/browse/SELC-5492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ