### PR TITLE
[SELC-5597] feat: GeoTaxonomySection does not set province when local value is pre-set

### DIFF
--- a/src/components/onboardingFormData/taxonomy/GeoTaxonomySection.tsx
+++ b/src/components/onboardingFormData/taxonomy/GeoTaxonomySection.tsx
@@ -270,7 +270,7 @@ export default function GeoTaxonomySection({
     } else if (option.desc.includes('COMUNE') && type === 'desc') {
       return `${finalDesc} (${option.province_abbreviation?.toUpperCase()}) comune`;
     } else if (option.desc.includes('COMUNE') && type === 'value') {
-      return `${finalDesc} (${option.province_abbreviation?.toUpperCase()})`;
+      return `${finalDesc} (${(option.province_abbreviation ? option.province_abbreviation : formik.values.county ?? '').toUpperCase()})`;
     } else {
       return '';
     }


### PR DESCRIPTION
… value is pre-set

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-5597] feat: GeoTaxonomySection does not set province when local value is pre-set

#### Motivation and Context

GeoTaxonomySection does not set province when local value is pre-set

#### How Has This Been Tested?

Tested that in the GeoTaxonomySection, when the local value is pre-set, there is also the value of the province

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5597]: https://pagopa.atlassian.net/browse/SELC-5597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ