### PR TITLE
[SELC-5591 Fix: CSV Encoding Issue to Support Accented Characters

### DIFF
--- a/src/views/onboardingProduct/components/StepUploadAggregates.tsx
+++ b/src/views/onboardingProduct/components/StepUploadAggregates.tsx
@@ -92,7 +92,9 @@ export function StepUploadAggregates({
       ),
     ].join('\r\n');
 
-    const blob = new Blob([csv], { type: 'text/csv' });
+    const csvWithBom = '\uFEFF' + csv;
+
+    const blob = new Blob([csvWithBom], { type: 'text/csv;charset=utf-8;' });
     const downloadUrl = URL.createObjectURL(blob);
 
     setErrorCsv(downloadUrl);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Added UTF-8 BOM (\uFEFF) to the generated CSV file to ensure correct encoding.
Updated Blob creation for the CSV file with explicit charset=utf-8 to properly handle accented characters.
Fixed issues where accented characters like è were being misrepresented in the exported CSV file (e.g., "è" showing as "Ã¨").
<!--- Describe your changes in detail -->

#### Motivation and Context
There was an issue where accented characters (e.g., è, à) were not correctly displayed in the generated CSV file. This was due to incorrect character encoding when exporting the file. By adding the UTF-8 BOM and specifying the encoding in the Blob, the CSV file now properly handles special characters, ensuring the correct display of all data in tools like Excel.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Generated multiple CSV files with accented characters and validated that they are correctly displayed when opened in Excel, Google Sheets, and plain text editors.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.