### PR TITLE
[SELC-5580] feat: read the category filter exposed on the cdn

### DIFF
--- a/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
+++ b/src/components/autocomplete/components/asyncAutocomplete/AsyncAutocompleteContainer.tsx
@@ -311,7 +311,7 @@ export default function AsyncAutocompleteContainer({
     setIsLoading(false);
   };
 
-  const searchByInstitutionType = (value: string, institutionType?: string) => {
+  const searchByInstitutionType = async (value: string, institutionType?: string) => {
     switch (institutionType) {
       case 'AS':
         void debounce(handleSearchByName, 100)(value, {
@@ -328,7 +328,7 @@ export default function AsyncAutocompleteContainer({
           value,
           endpoint,
           ENV.MAX_INSTITUTIONS_FETCH,
-          filterByCategory(institutionType, product?.id)
+          await filterByCategory(institutionType, product?.id)
         );
     }
   };
@@ -366,6 +366,7 @@ export default function AsyncAutocompleteContainer({
     if (value !== '') {
       setSelected(null);
       if (value.length >= 3 && isBusinessNameSelected && !isTaxCodeSelected) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         searchByInstitutionType(value, institutionType);
       } else if (
         (isTaxCodeSelected && value.length === 11) ||

--- a/src/lib/__mocks__/mockApiRequests.ts
+++ b/src/lib/__mocks__/mockApiRequests.ts
@@ -1045,6 +1045,22 @@ const mockRecipientCodeValidation = [
   { code: '2A3B4C', value: 'DENIED_NO_BILLING' },
 ];
 
+const mockedCategories = {
+  product: {
+    ["prod-pn"]: {
+      ipa: {
+        PA: "A1,A2,A3,A4,A5,A6,A7,A8,A9"
+      }
+    },
+    default: {
+      ipa: {
+        GSP: "B1,B2",
+        PA: "C1,C2,C3,C4,C5,C6,C7,C8,C9C,C10,C11,C12,C13,C14,C15,C16,C17,C18,C19,C20,C21,C22,C23,C24,C25,C26,C27,C28,C29,C30"
+      }
+    }
+  }
+};
+
 const noContent: Promise<AxiosResponse> = new Promise((resolve) =>
   resolve({
     status: 204,
@@ -1120,6 +1136,13 @@ export async function mockFetch(
   { endpoint, endpointParams }: Endpoint,
   { params, data }: AxiosRequestConfig
 ): Promise<AxiosResponse | AxiosError> {
+
+  if (endpoint === "CONFIG_JSON_CDN_URL") {
+    return new Promise((resolve) =>
+      resolve({ data: mockedCategories, status: 200, statusText: '200' } as AxiosResponse)
+    );
+  }
+
   if (endpoint === 'ONBOARDING_GET_SEARCH_PARTIES') {
     return new Promise((resolve) =>
       resolve({ data: mockPartyRegistry, status: 200, statusText: '200' } as AxiosResponse)
@@ -1321,7 +1344,7 @@ export async function mockFetch(
   if (endpoint === 'ONBOARDING_USER_VALIDATION') {
     if (
       ['CRTCTF90B12C123K', 'CRTCTF91B12C123K', 'CRTCTF92B12C123K'].indexOf((data as any)?.taxCode) >
-        -1 &&
+      -1 &&
       ((data as any)?.name !== 'CERTIFIED_NAME' || (data as any)?.surname !== 'CERTIFIED_SURNAME')
     ) {
       return buildOnboardingUserValidation409(

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -60,6 +60,12 @@ export const API = {
     URL: ENV.URL_API.ONBOARDING + '/product/{{productId}}',
   },
 
+  // configuration file on cdn
+
+  CONFIG_JSON_CDN_URL: {
+    URL: ENV.BASE_PATH_CDN_URL + '/assets/config.json',
+  },
+
   // institutions present on Ipa
   ONBOARDING_GET_SEARCH_PARTIES: {
     URL: ENV.URL_API.PARTY_REGISTRY_PROXY + '/institutions',
@@ -176,12 +182,31 @@ export const numericField = new RegExp('^[0-9]*$');
 export const currencyField = new RegExp(/^(0|[1-9][0-9]*(?:(,[0-9]*)*|[0-9]*))((\\.|,)[0-9]+)*$/);
 export const onlyCharacters = new RegExp(/^[A-Za-z\s]*$/);
 
-export const filterByCategory = (institutionType?: string, productId?: string) =>
-  productId === 'prod-pn'
-    ? 'L6,L4,L45,L35,L5,L17,L15,C14'
-    : institutionType === 'GSP'
-      ? 'L37,SAG'
-      : 'C17,C16,L10,L19,L13,L2,C10,L20,L21,L22,L15,L1,C13,C5,L40,L11,L39,L46,L8,L34,L7,L35,L45,L47,L6,L12,L24,L28,L42,L36,L44,C8,C3,C7,C14,L16,C11,L33,C12,L43,C2,L38,C1,L5,L4,L31,L18,L17,S01,SA';
+export const filterByCategory = async (institutionType?: string, productId?: string) => {
+  try {
+    const response = await fetch(
+      `${ENV.BASE_PATH_CDN_URL}/assets/config.json`,
+      {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+    if (!response.ok) {
+      console.error(`Response status: ${response.status}`);
+    } else {
+      const res = await response.json();
+      if (productId === 'prod-pn') {
+        return res.product['prod-pn'].ipa.PA;
+      } else if (productId !== 'prod-pn' && institutionType === 'GSP') {
+        return res.product.default.ipa.GSP;
+      } else {
+        return res.product.defualt.ipa.PA;
+      }
+    }
+  } catch (error: any) {
+    console.error(error.message);
+  }
+};
 
 export const canInvoice = (institutionType?: string, productId?: string) =>
   institutionType !== 'SA' &&

--- a/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
+++ b/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
@@ -717,7 +717,7 @@ const executeStepSearchParty = async (
             categories:
               institutionType === 'SA' || institutionType === 'AS'
                 ? undefined
-                : filterByCategory(institutionType.toUpperCase(), productId),
+                : await filterByCategory(institutionType.toUpperCase(), productId),
             page: 1,
             search: 'XXX',
           },


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-5580] feat: read the category filter exposed on the cdn

#### Motivation and Context

the categories has been exposed on the storage of the cdn and to read them we have to make a call for retrive those informations

#### How Has This Been Tested?

Tested that those information are retrived

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5580]: https://pagopa.atlassian.net/browse/SELC-5580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ