### PR TITLE
[SELC-5704] fix: fixed the "P.IVA" checkbox when the CF value has not yet been set

### DIFF
--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -746,10 +746,7 @@ export default function PersonalAndBillingDataSection({
                   <Box display="flex" alignItems="center">
                     <Checkbox
                       id="taxCodeEquals2VatNumber"
-                      checked={
-                        stepHistoryState.isTaxCodeEquals2PIVA ||
-                        formik.values.taxCode === formik.values.vatNumber
-                      }
+                      checked={stepHistoryState.isTaxCodeEquals2PIVA}
                       disabled={isPremium || formik.values.taxCode.length !== 11}
                       inputProps={{
                         'aria-label': t(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-5704] fix: fixed the "P.IVA" checkbox when the CF value has not yet been set

#### Motivation and Context

the "P.IVA" checkbox when the CF value wasn't setted yet, it was already checked.

#### How Has This Been Tested?

Tested that when the CF value it's not setted yest, the checkbox it's not checked. When the cf value is entered, the checkbox it's enabled and clickable

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5704]: https://pagopa.atlassian.net/browse/SELC-5704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ