### PR TITLE
[SELC-6027] feat: View and path incorrect for procut prod-io-premium

### DIFF
--- a/src/components/BodyLogger.tsx
+++ b/src/components/BodyLogger.tsx
@@ -1,21 +1,34 @@
 import { useContext, useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { Box } from '@mui/system';
 import { Footer, Header } from '@pagopa/selfcare-common-frontend/lib';
 import { trackEvent } from '@pagopa/selfcare-common-frontend/lib/services/analyticsService';
 import i18n from '@pagopa/selfcare-common-frontend/lib/locale/locale-utils';
 import { logAction } from '../lib/action-log';
 import { ENV } from '../utils/env';
+import { ROUTES } from '../utils/constants';
 import { Main } from './Main';
 import { HeaderContext, UserContext } from './../lib/context';
 
 export function BodyLogger() {
   const { user } = useContext(UserContext);
   const location = useLocation();
+  const history = useHistory();
   const [subHeaderVisible, setSubHeaderVisible] = useState<boolean>(false);
   const [onExit, setOnExit] = useState<((exitAction: () => void) => void) | undefined>();
   const [enableLogin, setEnableLogin] = useState<boolean>(true);
   const [showDocBtn, setShowDocBtn] = useState(false);
+
+  useEffect(() => {
+    if (location.pathname === '/onboarding/prod-io-premium') {
+      history.push(
+        ROUTES.ONBOARDING_PREMIUM.PATH.replace(':productId', 'prod-io').replace(
+          ':subProductId',
+          'prod-io-premium'
+        )
+      );
+    }
+  }, []);
 
   useEffect(() => {
     if (i18n.language === 'it') {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-6027] feat: View and path incorrect for procut prod-io-premium

#### Motivation and Context

redirect to corret premium path of prod-io product if is typed in the subProductId without the productId before

#### How Has This Been Tested?

Tested that if typed in the research bar of the browser the incorrect path "onboarding/prod-io-premium" it'll be redirect directly to the correct one "onboarding/prod-io/prod-io-premium"

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-6027]: https://pagopa.atlassian.net/browse/SELC-6027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ