### PR TITLE
[SELC-6168] Feat: added longTermPayments boolean field in the onboarding request

### DIFF
--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -224,7 +224,7 @@ export default {
         isPartyProvidingAService: 'L’ente eroga un servizio rivolto ai cittadini?',
         gpuRequestAccessFor:
           'Per quali servizi di pubblica utilità e/o di interesse generale l’ente richiede l’accesso?',
-        frequencyOfPayment: 'La frequenza dei pagamenti è continuativa?',
+        longTermPayments: 'La frequenza dei pagamenti è continuativa?',
       },
       placeholder: {
         registerBoardList: 'Registro/Albo/Elenco',

--- a/src/model/AdditionalGpuInformations.ts
+++ b/src/model/AdditionalGpuInformations.ts
@@ -2,6 +2,7 @@ export type AdditionalGpuInformations = {
     businessRegisterNumber?: string;
     legalRegisterNumber?: string;
     legalRegisterName?: string;
+    longTermPayments?: boolean;
     manager: boolean;
     managerAuthorized: boolean;
     managerEligible: boolean;
@@ -12,5 +13,5 @@ export type AdditionalGpuInformations = {
 export type AdditionalGpuInformationsRadio = {
     isPartyRegistered: boolean | null;
     isPartyProvidingAService: boolean | null;
-    frequencyOfPayment: boolean | null;
+    longTermPayments: boolean | null;
 };

--- a/src/views/onboardingProduct/OnboardingProduct.tsx
+++ b/src/views/onboardingProduct/OnboardingProduct.tsx
@@ -394,6 +394,7 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
       businessRegisterNumber: newAdditionalGpuInformations?.businessRegisterNumber,
       legalRegisterNumber: newAdditionalGpuInformations?.legalRegisterNumber,
       legalRegisterName: newAdditionalGpuInformations.legalRegisterName,
+      longTermPayments: newAdditionalGpuInformations.longTermPayments,
       manager: newAdditionalGpuInformations.manager,
       managerAuthorized: newAdditionalGpuInformations.managerAuthorized,
       managerEligible: newAdditionalGpuInformations.managerEligible,

--- a/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
+++ b/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
@@ -1135,7 +1135,7 @@ const executeStepAdditionalGpuInformations = async () => {
   const isPartyProvidingAServiceFalse = document.getElementById(
     'isPartyProvidingAServiceFalse'
   ) as HTMLElement;
-  const frequencyOfPaymentTrue = document.getElementById('frequencyOfPaymentTrue') as HTMLElement;
+  const longTermPaymentsTrue = document.getElementById('longTermPaymentsTrue') as HTMLElement;
   const manager = document.getElementById('manager') as HTMLElement;
   const managerAuthorized = document.getElementById('managerAuthorized') as HTMLElement;
   const managerEligible = document.getElementById('managerEligible') as HTMLElement;
@@ -1153,7 +1153,7 @@ const executeStepAdditionalGpuInformations = async () => {
 
   fireEvent.click(isPartyRegisteredTrue);
   fireEvent.click(isPartyProvidingAServiceTrue);
-  fireEvent.click(frequencyOfPaymentTrue);
+  fireEvent.click(longTermPaymentsTrue);
 
   expect(continueButton).not.toBeDisabled();
 

--- a/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
+++ b/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
@@ -2030,16 +2030,16 @@ const billingData2billingDataRequest = (
   recipientCode: errorOnSubmit
     ? 'A2B3C4'
     : // MERGE THIS CONDITIONS
-    institutionType === 'PSP'
-    ? 'A1B2C3'
-    : (from === 'IPA' ||
-        institutionType === 'GSP' ||
-        (from === 'NO_IPA' && institutionType === 'GPU')) &&
-      typeOfSearch !== 'aooCode'
-    ? typeOfSearch === 'taxCode'
-      ? 'A3B4C5'
-      : 'A1B2C3'
-    : undefined,
+      institutionType === 'PSP'
+      ? 'A1B2C3'
+      : (from === 'IPA' ||
+            institutionType === 'GSP' ||
+            (from === 'NO_IPA' && institutionType === 'GPU')) &&
+          typeOfSearch !== 'aooCode'
+        ? typeOfSearch === 'taxCode'
+          ? 'A3B4C5'
+          : 'A1B2C3'
+        : undefined,
 });
 
 const verifySubmit = async (
@@ -2087,33 +2087,33 @@ const verifySubmit = async (
           originId: errorOnSubmit
             ? mockPartyRegistry.items[1].originId
             : from === 'NO_IPA'
-            ? undefined
-            : from === 'ANAC'
-            ? mockedANACParties[0].originId
-            : from === 'IVASS'
-            ? haveTaxCode
-              ? isForeignInsurance
-                ? mockedInsuranceResource.items[0].originId
-                : mockedInsuranceResource.items[2].originId
-              : mockedInsuranceResource.items[4].originId
-            : from === 'INFOCAMERE'
-            ? undefined
-            : from === 'PDND_INFOCAMERE'
-            ? '00112233445'
-            : typeOfSearch === 'taxCode'
-            ? mockedParties[0].originId
-            : typeOfSearch === 'aooCode'
-            ? mockedAoos[0].codiceUniAoo
-            : typeOfSearch === 'uoCode'
-            ? mockedUos[0].codiceUniUo
-            : (institutionType === 'PRV' && productId === 'prod-pagopa') ||
-              (institutionType === 'GPU' &&
-                (productId === 'prod-pagopa' ||
-                  productId === 'prod-interop' ||
-                  productId === 'prod-io-sign' ||
-                  productId === 'prod-io'))
-            ? undefined
-            : '991',
+              ? undefined
+              : from === 'ANAC'
+                ? mockedANACParties[0].originId
+                : from === 'IVASS'
+                  ? haveTaxCode
+                    ? isForeignInsurance
+                      ? mockedInsuranceResource.items[0].originId
+                      : mockedInsuranceResource.items[2].originId
+                    : mockedInsuranceResource.items[4].originId
+                  : from === 'INFOCAMERE'
+                    ? undefined
+                    : from === 'PDND_INFOCAMERE'
+                      ? '00112233445'
+                      : typeOfSearch === 'taxCode'
+                        ? mockedParties[0].originId
+                        : typeOfSearch === 'aooCode'
+                          ? mockedAoos[0].codiceUniAoo
+                          : typeOfSearch === 'uoCode'
+                            ? mockedUos[0].codiceUniUo
+                            : (institutionType === 'PRV' && productId === 'prod-pagopa') ||
+                                (institutionType === 'GPU' &&
+                                  (productId === 'prod-pagopa' ||
+                                    productId === 'prod-interop' ||
+                                    productId === 'prod-io-sign' ||
+                                    productId === 'prod-io'))
+                              ? undefined
+                              : '991',
           taxCode: errorOnSubmit
             ? mockPartyRegistry.items[1].taxCode
             : from === 'NO_IPA'
@@ -2150,15 +2150,12 @@ const verifySubmit = async (
                 }
               : undefined,
           gpuData:
-            institutionType === 'GPU' &&
-            (productId === 'prod-pagopa' ||
-              productId === 'prod-interop' ||
-              productId === 'prod-io-sign' ||
-              productId === 'prod-io')
+            institutionType === 'GPU' && productId === 'prod-pagopa'
               ? {
                   businessRegisterNumber: 'Comunale12',
                   legalRegisterNumber: '250301',
                   legalRegisterName: 'SkiPass',
+                  longTermPayments: true,
                   manager: true,
                   managerAuthorized: true,
                   managerEligible: false,

--- a/src/views/onboardingProduct/components/StepAdditionalGpuInformations.tsx
+++ b/src/views/onboardingProduct/components/StepAdditionalGpuInformations.tsx
@@ -32,6 +32,7 @@ export function StepAdditionalGpuInformations({ back, forward /* origin, originI
       businessRegisterNumber: undefined,
       legalRegisterNumber: undefined,
       legalRegisterName: undefined,
+      longTermPayments: undefined,
       manager: false,
       managerAuthorized: false,
       managerEligible: false,
@@ -42,7 +43,7 @@ export function StepAdditionalGpuInformations({ back, forward /* origin, originI
   const [radioValues, setRadioValues] = useState<AdditionalGpuInformationsRadio>({
     isPartyRegistered: null,
     isPartyProvidingAService: null,
-    frequencyOfPayment: null,
+    longTermPayments: null,
   });
 
   const [errors, setErrors] = useState<{
@@ -56,64 +57,72 @@ export function StepAdditionalGpuInformations({ back, forward /* origin, originI
 
   // eslint-disable-next-line sonarjs/cognitive-complexity
   const handleAbleDisableAndCleanField = (fieldName: string, value: any) => {
-    // Una sola chiamata per aggiornare lo stato
-    setAdditionalGpuInformations((prev) => {
-      // eslint-disable-next-line functional/no-let
-      let updatedState = { ...prev };
+    switch (fieldName) {
+      case 'isPartyRegistered':
+      case 'isPartyProvidingAService':
+        // Una sola chiamata per aggiornare lo stato
+        setAdditionalGpuInformations((prev) => {
+          // eslint-disable-next-line functional/no-let
+          let updatedState = { ...prev };
 
-      if (fieldName === 'isPartyRegistered' && value === 'false') {
-        // Ripulisci i campi collegati quando il valore di isPartyRegistered è 'false'
-        updatedState = {
-          ...updatedState,
-          businessRegisterNumber: undefined,
-          legalRegisterNumber: undefined,
-        };
-      }
+          if (fieldName === 'isPartyRegistered' && value === 'false') {
+            // Ripulisci i campi collegati quando il valore di isPartyRegistered è 'false'
+            updatedState = {
+              ...updatedState,
+              businessRegisterNumber: undefined,
+              legalRegisterNumber: undefined,
+            };
+          }
 
-      if (fieldName === 'isPartyProvidingAService' && value === 'false') {
-        // Ripulisci il campo collegato quando il valore di isPartyProvidingAService è 'false'
-        updatedState = {
-          ...updatedState,
-          legalRegisterName: undefined,
-        };
-      }
-      return updatedState;
-    });
+          if (fieldName === 'isPartyProvidingAService' && value === 'false') {
+            // Ripulisci il campo collegato quando il valore di isPartyProvidingAService è 'false'
+            updatedState = {
+              ...updatedState,
+              legalRegisterName: undefined,
+            };
+          }
+          console.log('updatedState', updatedState);
+          return updatedState;
+        });
 
-    // Gestione del disabilitamento dei campi
-    setFieldDisabled((prev) => {
-      const updatedDisabledState = { ...prev };
+        // Gestione del disabilitamento dei campi
+        setFieldDisabled((prev) => {
+          const updatedDisabledState = { ...prev };
 
-      if (fieldName === 'isPartyRegistered') {
-        // eslint-disable-next-line functional/immutable-data
-        updatedDisabledState.isPartyRegistered = value === 'false';
-      }
+          if (fieldName === 'isPartyRegistered') {
+            // eslint-disable-next-line functional/immutable-data
+            updatedDisabledState.isPartyRegistered = value === 'false';
+          }
 
-      if (fieldName === 'isPartyProvidingAService') {
-        // eslint-disable-next-line functional/immutable-data
-        updatedDisabledState.isPartyProvidingAService = value === 'false';
-      }
+          if (fieldName === 'isPartyProvidingAService') {
+            // eslint-disable-next-line functional/immutable-data
+            updatedDisabledState.isPartyProvidingAService = value === 'false';
+          }
 
-      return updatedDisabledState;
-    });
+          return updatedDisabledState;
+        });
 
-    setErrors((prev) => {
-      const updatedErrors = { ...prev };
+        setErrors((prev) => {
+          const updatedErrors = { ...prev };
 
-      if (fieldName === 'isPartyRegistered' && value === 'false') {
-        // eslint-disable-next-line functional/immutable-data
-        delete updatedErrors.businessRegisterNumber;
-        // eslint-disable-next-line functional/immutable-data
-        delete updatedErrors.legalRegisterNumber;
-      }
+          if (fieldName === 'isPartyRegistered' && value === 'false') {
+            // eslint-disable-next-line functional/immutable-data
+            delete updatedErrors.businessRegisterNumber;
+            // eslint-disable-next-line functional/immutable-data
+            delete updatedErrors.legalRegisterNumber;
+          }
 
-      if (fieldName === 'isPartyProvidingAService' && value === 'false') {
-        // eslint-disable-next-line functional/immutable-data
-        delete updatedErrors.legalRegisterName;
-      }
+          if (fieldName === 'isPartyProvidingAService' && value === 'false') {
+            // eslint-disable-next-line functional/immutable-data
+            delete updatedErrors.legalRegisterName;
+          }
 
-      return updatedErrors;
-    });
+          return updatedErrors;
+        });
+        break;
+      default:
+        break;
+    }
   };
 
   const handleFieldChange = (
@@ -135,8 +144,8 @@ export function StepAdditionalGpuInformations({ back, forward /* origin, originI
             fieldName === 'businessRegisterNumber'
               ? onlyAlfaNumericValue
               : fieldName === 'legalRegisterNumber'
-              ? onlyNumberValue
-              : onlyAlfaNumericWithSpaceValue,
+                ? onlyNumberValue
+                : onlyAlfaNumericWithSpaceValue,
         }));
         return;
       case 'checkbox':
@@ -146,6 +155,10 @@ export function StepAdditionalGpuInformations({ back, forward /* origin, originI
         }));
         break;
       case 'radio':
+        setAdditionalGpuInformations((prev) => ({
+          ...prev,
+          [fieldName]: fieldName === 'longTermPayments' ? value === 'true' : value,
+        }));
         setRadioValues((prev) => ({
           ...prev,
           [fieldName]: value === 'true',
@@ -349,29 +362,29 @@ export function StepAdditionalGpuInformations({ back, forward /* origin, originI
           <Grid item xs={12} my={1}>
             <Typography sx={{ fontSize: '18px', fontWeight: 600 }}>
               {' '}
-              {t('additionalGpuDataPage.firstBlock.question.frequencyOfPayment')}
+              {t('additionalGpuDataPage.firstBlock.question.longTermPayments')}
             </Typography>
           </Grid>
           <Grid item xs={12} my={1}>
             <FormControl>
               <RadioGroup
-                id="frequencyOfPayment"
-                aria-labelledby="frequencyOfPayment"
-                name="frequencyOfPayment"
-                value={radioValues.frequencyOfPayment}
+                id="longTermPayments"
+                aria-labelledby="longTermPayments"
+                name="longTermPayments"
+                value={radioValues.longTermPayments}
                 onChange={(event) =>
-                  handleFieldChange('frequencyOfPayment', event.target.value, 'radio')
+                  handleFieldChange('longTermPayments', event.target.value, 'radio')
                 }
               >
                 <FormControlLabel
-                  id="frequencyOfPaymentTrue"
+                  id="longTermPaymentsTrue"
                   value="true"
                   control={<Radio />}
                   label={t('additionalGpuDataPage.firstBlock.yes')}
                 />
                 <FormControlLabel
                   value="false"
-                  id="frequencyOfPaymentFalse"
+                  id="longTermPaymentsFalse"
                   control={<Radio />}
                   label={t('additionalGpuDataPage.firstBlock.no')}
                 />
@@ -503,7 +516,7 @@ export function StepAdditionalGpuInformations({ back, forward /* origin, originI
             disabled:
               radioValues.isPartyRegistered === null ||
               radioValues.isPartyProvidingAService === null ||
-              radioValues.frequencyOfPayment === null,
+              radioValues.longTermPayments === null,
           }}
         />
       </Grid>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-6168] Feat: added longTermPayments boolean field in the onboarding request

#### Motivation and Context

New longTermPayments boolean field in the onboarding request  gpuData object for additionalGpuInformation. this feature is required for the onboarding flow of a GPU

#### How Has This Been Tested?

Tested that the new field longTermPayments it's send in the onboarding request of a GPU

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-6168]: https://pagopa.atlassian.net/browse/SELC-6168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ