### PR TITLE
Feat: Updated io-premium flow

### DIFF
--- a/src/views/onboardingPremium/OnboardingPremium.tsx
+++ b/src/views/onboardingPremium/OnboardingPremium.tsx
@@ -225,6 +225,7 @@ function OnboardingPremiumComponent() {
           productId,
           subProductId,
           setLoading,
+          setActiveStep,
           forward: forwardWithInputs,
         }),
     },

--- a/src/views/onboardingPremium/__tests__/OnboardingPremium.test.tsx
+++ b/src/views/onboardingPremium/__tests__/OnboardingPremium.test.tsx
@@ -108,9 +108,9 @@ const successOnboardingSubProductTitle = 'La richiesta di adesione è stata invi
 const errorOnboardingSubProductTitle = 'Qualcosa è andato storto';
 
 test('Test: Bad productId and subProductId', async () => {
-  renderComponent('error', 'error');
-  await waitFor(() => expect(fetchWithLogsSpy).toBeCalledTimes(5));
-  await waitFor(() => screen.getByText('Impossibile individuare il prodotto desiderato'));
+  renderComponent('prod-io', 'prod-io');
+  await waitFor(() => expect(fetchWithLogsSpy).toBeCalledTimes(4));
+  await waitFor(() => screen.findByText('Impossibile individuare il prodotto desiderato'));
 });
 
 test('Test: Error retrieving onboarding info', async () => {
@@ -326,12 +326,12 @@ const executeStepSelectInstitution = async (partyName: string) => {
   const continueButton = screen.getByText('Continua');
   expect(continueButton).toBeDisabled();
 
-  await waitFor(() => expect(fetchWithLogsSpy).toBeCalledTimes(5));
+  await waitFor(() => expect(fetchWithLogsSpy).toBeCalledTimes(4));
   const party = screen.getByText(partyName);
 
   expect(party).toBeTruthy();
 
-  expect(fetchWithLogsSpy).toBeCalledTimes(5);
+  expect(fetchWithLogsSpy).toBeCalledTimes(4);
 
   fireEvent.click(party);
 

--- a/src/views/onboardingPremium/components/SubProductStepVerifyInputs.tsx
+++ b/src/views/onboardingPremium/components/SubProductStepVerifyInputs.tsx
@@ -1,5 +1,5 @@
 import { AxiosError, AxiosResponse } from 'axios';
-import { useContext, useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useContext, useEffect, useState } from 'react';
 import { trackAppError } from '@pagopa/selfcare-common-frontend/lib/services/analyticsService';
 import { SelfcareParty, Product, StepperStepComponentProps } from '../../../../types';
 import { HeaderContext, UserContext } from '../../../lib/context';
@@ -14,11 +14,12 @@ type Props = StepperStepComponentProps & {
   productId: string;
   subProductId: string;
   setLoading: (loading: boolean) => void;
+  setActiveStep: Dispatch<SetStateAction<number>>;
 };
 
 const checkProduct = async (
   id: string,
-  setter: (product: Product | null) => void,
+  setter: (product: Product | undefined) => void,
   setRequiredLogin: (required: boolean) => void
 ) => {
   const onboardingProducts = await fetchWithLogs(
@@ -32,63 +33,42 @@ const checkProduct = async (
     const product = (onboardingProducts as AxiosResponse).data;
     setter(product);
   } else if ((onboardingProducts as AxiosError).response?.status === 404) {
-    setter(null);
+    setter(undefined);
   } else {
     console.error('Unexpected response', (onboardingProducts as AxiosError).response);
-    setter(null);
+    setter(undefined);
   }
 };
 
 const handleSearchUserParties = async (
   setParties: (parties: Array<SelfcareParty>) => void,
-  setRequiredLogin: (required: boolean) => void
+  setRequiredLogin: (required: boolean) => void,
+  _productId: string,
+  subProductId: string
 ) => {
-  const searchResponseBase = await fetchWithLogs(
-    { endpoint: 'ONBOARDING_GET_USER_PARTIES' },
-    {
-      method: 'GET',
-      params: {
-        productFilter: 'prod-io',
-      },
-    },
-    () => setRequiredLogin(true)
-  );
 
   const searchResponsePremium = await fetchWithLogs(
     { endpoint: 'ONBOARDING_GET_USER_PARTIES' },
     {
       method: 'GET',
       params: {
-        productFilter: 'prod-io-premium',
+        productId: subProductId,
       },
     },
     () => setRequiredLogin(true)
   );
-  const partiesWithBaseProduct = (searchResponseBase as AxiosResponse).data as Array<SelfcareParty>;
+  
   const partiesWithPremiumProduct = (searchResponsePremium as AxiosResponse).data;
 
-  const partiesWithoutPremium = partiesWithBaseProduct.filter(
-    (pb) => !partiesWithPremiumProduct.find((pp: any) => pb.id === pp.id)
-  );
-
-  const outcome = getFetchOutcome(searchResponseBase);
+  const outcome = getFetchOutcome(searchResponsePremium);
 
   if (outcome === 'success') {
-    if (process.env.REACT_APP_MOCK_API === 'true') {
-      setParties(
-        partiesWithBaseProduct.map((p) => ({
-          ...p,
-          urlLogo: buildUrlLogo(p.id),
-        }))
-      );
-    } else {
-      setParties(
-        partiesWithoutPremium.map((p) => ({
-          ...p,
-          urlLogo: buildUrlLogo(p.id),
-        }))
-      );
-    }
+    setParties(
+      partiesWithPremiumProduct.map((p: any) => ({
+        ...p,
+        urlLogo: buildUrlLogo(p.id),
+      }))
+    );
   } else {
     setParties([]);
   }
@@ -100,14 +80,15 @@ function SubProductStepVerifyInputs({
   subProductId,
   requestId,
   setLoading,
+  setActiveStep,
 }: Props) {
   const [error, setError] = useState<boolean>(false);
   const { setOnExit } = useContext(HeaderContext);
   const { setRequiredLogin } = useContext(UserContext);
 
-  const [selectedSubProduct, setSelectedSubProduct] = useState<Product | null>();
+  const [selectedSubProduct, setSelectedSubProduct] = useState<Product | undefined>();
   const [selectedProduct, setSelectedProduct] = useState<Product | null>();
-
+  const [dataFetched, setDataFetched] = useState(false);
   const [parties, setParties] = useState<Array<SelfcareParty>>();
 
   const submit = () => {
@@ -115,7 +96,7 @@ function SubProductStepVerifyInputs({
     Promise.all([
       checkProduct(productId, setSelectedProduct, setRequiredLogin),
       checkProduct(subProductId, setSelectedSubProduct, setRequiredLogin),
-      handleSearchUserParties(setParties, setRequiredLogin),
+      handleSearchUserParties(setParties, setRequiredLogin, productId, subProductId),
     ])
       .catch((reason) => {
         trackAppError({
@@ -131,19 +112,23 @@ function SubProductStepVerifyInputs({
   };
 
   useEffect(() => {
-    submit();
-  }, [productId, subProductId]);
+    if (!dataFetched) {
+      submit();
+      setDataFetched(true);
+    }
+  }, [productId, subProductId, dataFetched]);
 
   useEffect(() => {
-    if (
-      selectedProduct &&
-      selectedSubProduct &&
-      parties &&
-      selectedSubProduct.parentId === productId
-    ) {
-      forward(selectedProduct, selectedSubProduct, parties);
-    } else {
-      setError(true);
+    if (selectedProduct && selectedSubProduct && parties !== undefined) {
+      if (selectedSubProduct.parentId === productId) {
+        forward(selectedProduct, selectedSubProduct, parties);
+      } else {
+        setError(true);
+      }
+
+      if (parties.length === 0) {
+        setActiveStep(2);
+      }
     }
   }, [selectedProduct, selectedSubProduct, parties]);
 

--- a/src/views/onboardingPremium/components/SubProductStepVerifyInputs.tsx
+++ b/src/views/onboardingPremium/components/SubProductStepVerifyInputs.tsx
@@ -88,7 +88,6 @@ function SubProductStepVerifyInputs({
 
   const [selectedSubProduct, setSelectedSubProduct] = useState<Product | undefined>();
   const [selectedProduct, setSelectedProduct] = useState<Product | null>();
-  const [dataFetched, setDataFetched] = useState(false);
   const [parties, setParties] = useState<Array<SelfcareParty>>();
 
   const submit = () => {
@@ -112,11 +111,8 @@ function SubProductStepVerifyInputs({
   };
 
   useEffect(() => {
-    if (!dataFetched) {
       submit();
-      setDataFetched(true);
-    }
-  }, [productId, subProductId, dataFetched]);
+  }, [productId, subProductId]);
 
   useEffect(() => {
     if (selectedProduct && selectedSubProduct && parties !== undefined) {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Feat: Updated io-premium flow

#### Motivation and Context

Updated ONBOARDING_GET_USER_PARTIES Api call in the first step of Premium onboarding flow. now the API with the filter  productId is called just one time and no more for both product father and son, but just for the son with the subProductId.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.