### PR TITLE
[SELC-6800] Feat: fixed the page of conflict error for the pagoPA insights flow

### DIFF
--- a/src/views/onboardingPremium/components/SubProductStepSubmit.tsx
+++ b/src/views/onboardingPremium/components/SubProductStepSubmit.tsx
@@ -14,6 +14,7 @@ import { MessageNoAction } from '../../../components/MessageNoAction';
 import { unregisterUnloadEvent } from '../../../utils/unloadEvent-utils';
 import { OnboardingFormData } from '../../../model/OnboardingFormData';
 import { ENV } from '../../../utils/env';
+import AlreadyOnboarded from '../../AlreadyOnboarded';
 import { subProductSubmitFetch } from './SubProductSubmitFetch';
 
 type Props = StepperStepComponentProps & {
@@ -69,9 +70,10 @@ function SubProductStepSubmit({
   institutionType,
   pricingPlan,
   origin,
-  originId
+  originId,
 }: Props) {
   const [error, setError] = useState<boolean>(false);
+  const [conflictError, setConflictError] = useState<boolean>(false);
   const { setOnExit } = useContext(HeaderContext);
   const { setRequiredLogin } = useContext(UserContext);
 
@@ -91,7 +93,8 @@ function SubProductStepSubmit({
         setError,
         forward,
         origin,
-        originId
+        originId,
+        setConflictError,
       })
         .catch((_reason: any) => {
           setError(true);
@@ -111,6 +114,12 @@ function SubProductStepSubmit({
         });
     }
   }, []);
-  return error ? <MessageNoAction {...errorOutCome} /> : <></>;
+  return error && !conflictError ? (
+    <MessageNoAction {...errorOutCome} />
+  ) : error && conflictError ? (
+    <AlreadyOnboarded selectedProduct={subProduct} />
+  ) : (
+    <></>
+  );
 }
 export default SubProductStepSubmit;

--- a/src/views/onboardingPremium/components/SubProductSubmitFetch.ts
+++ b/src/views/onboardingPremium/components/SubProductSubmitFetch.ts
@@ -23,6 +23,7 @@ type Props = {
   forward: () => void;
   origin: string;
   originId: string;
+  setConflictError: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const subProductSubmitFetch = async ({
@@ -38,7 +39,8 @@ export const subProductSubmitFetch = async ({
   setError,
   forward,
   origin,
-  originId
+  originId,
+  setConflictError,
 }: Props) => {
   const postLegalsResponse = await fetchWithLogs(
     {
@@ -102,10 +104,17 @@ export const subProductSubmitFetch = async ({
     });
     forward();
   } else {
-    const event =
-      (postLegalsResponse as AxiosError<Problem>).response?.status === 409
-        ? 'ONBOARDING_PREMIUM_SEND_CONFLICT_ERROR_FAILURE'
-        : 'ONBOARDING_PREMIUM_SEND_FAILURE';
+    // eslint-disable-next-line functional/no-let
+    let event;
+
+    if ((postLegalsResponse as AxiosError<Problem>).response?.status === 409) {
+      event = 'ONBOARDING_PREMIUM_SEND_CONFLICT_ERROR_FAILURE';
+      setConflictError(true);
+    } else {
+      event = 'ONBOARDING_PREMIUM_SEND_FAILURE';
+      setConflictError(false);
+    }
+
     trackEvent(event, {
       party_id: externalInstitutionId,
       request_id: requestId,

--- a/src/views/onboardingPremium/components/SubProductSubmitFetch.ts
+++ b/src/views/onboardingPremium/components/SubProductSubmitFetch.ts
@@ -104,16 +104,12 @@ export const subProductSubmitFetch = async ({
     });
     forward();
   } else {
-    // eslint-disable-next-line functional/no-let
-    let event;
+    const event =
+      (postLegalsResponse as AxiosError<Problem>).response?.status === 409
+        ? 'ONBOARDING_PREMIUM_SEND_CONFLICT_ERROR_FAILURE'
+        : 'ONBOARDING_PREMIUM_SEND_FAILURE';
 
-    if ((postLegalsResponse as AxiosError<Problem>).response?.status === 409) {
-      event = 'ONBOARDING_PREMIUM_SEND_CONFLICT_ERROR_FAILURE';
-      setConflictError(true);
-    } else {
-      event = 'ONBOARDING_PREMIUM_SEND_FAILURE';
-      setConflictError(false);
-    }
+    setConflictError((postLegalsResponse as AxiosError<Problem>).response?.status === 409);
 
     trackEvent(event, {
       party_id: externalInstitutionId,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-6800] Feat: fixed the page of conflict error for the pagoPA insights flow

#### Motivation and Context

In the pagoPA insights membership flow, the error "your institution has already joined" returns in the case of 409

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-6800]: https://pagopa.atlassian.net/browse/SELC-6800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ