### PR TITLE
Fixed the user validation process in the steps of AddManager and AddAdmin

### DIFF
--- a/src/components/steps/StepAddManager.tsx
+++ b/src/components/steps/StepAddManager.tsx
@@ -81,19 +81,10 @@ export function StepAddManager({
     }
   }, [premiumFlow]);
 
-  const onUserValidateSuccess = () => {
-    setIsGenericError(false);
-    onForwardAction();
-  };
-
   const onUserValidateError = (userId: string, errors: { [fieldName: string]: Array<string> }) => {
     setPeopleErrors({
       [userId]: errors,
     });
-  };
-
-  const onUserValidateGenericError = () => {
-    setIsGenericError(true);
   };
 
   const checkManager = async (user: UserOnCreate) => {
@@ -149,9 +140,8 @@ export function StepAddManager({
       externalInstitutionId,
       user,
       prefix,
-      onUserValidateSuccess,
+      onForwardAction,
       onUserValidateError,
-      onUserValidateGenericError,
       () => setRequiredLogin(true),
       setLoading,
       subProduct ? 'ONBOARDING_PREMIUM_ADD_MANAGER' : 'ONBOARDING_ADD_MANAGER'

--- a/src/utils/api/userValidate.ts
+++ b/src/utils/api/userValidate.ts
@@ -8,9 +8,8 @@ export async function userValidate(
   partyId: string,
   user: UserOnCreate,
   userId: string,
-  onSuccess: (userId: string) => void,
+  onForwardAction: () => void,
   onValidationError: (userId: string, errors: { [fieldName: string]: Array<string> }) => void,
-  onGenericError: (userId: string) => void,
   onRedirectToLogin: () => void,
   setLoading: (loading: boolean) => void,
   eventName: string
@@ -35,9 +34,7 @@ export async function userValidate(
   const result = getFetchOutcome(resultValidation);
   const errorBody = (resultValidation as AxiosError<ProblemUserValidate>).response?.data;
 
-  if (result === 'success') {
-    onSuccess(userId);
-  } else if (
+if (
     result === 'error' &&
     (resultValidation as AxiosError<Problem>).response?.status === 409 &&
     errorBody
@@ -51,11 +48,7 @@ export async function userValidate(
       Object.fromEntries(errorBody?.invalidParams?.map((e: any) => [e.name, ['conflict']]) ?? [])
     );
   } else {
-    trackEvent(`${eventName}_GENERIC_ERROR`, {
-      party_id: partyId,
-      reason: errorBody?.detail,
-    });
-    onGenericError(userId);
+    onForwardAction();
   }
   setLoading(false);
 }

--- a/src/utils/test-utils.tsx
+++ b/src/utils/test-utils.tsx
@@ -282,7 +282,15 @@ export const executeStepAddAdmin = async (
 
   await checkCertifiedUserValidation('delegate-initial', addUserFlow, onlyAdmin);
 
-  await fillUserForm('delegate-initial', 'SRNNMA80A01B354S', 'a@a.AA', addUserFlow, onlyAdmin);
+  await fillUserForm(
+    'delegate-initial',
+    'RSSLCU80A01F205N',
+    'a@a.AA',
+    addUserFlow,
+    onlyAdmin,
+    'LUCA',
+    'ROSSI'
+  );
 
   expect(continueButton).toBeEnabled();
   if (!addUserFlow) {
@@ -652,10 +660,10 @@ export const verifySubmit = async (
           },
           {
             email: 'a@a.aa',
-            name: 'NAME',
+            name: 'LUCA',
             role: 'DELEGATE',
-            surname: 'SURNAME',
-            taxCode: 'SRNNMA80A01B354S',
+            surname: 'ROSSI',
+            taxCode: 'RSSLCU80A01F205N',
           },
         ].filter((u) => (institutionType === 'PT' ? u.role !== 'MANAGER' : u)),
         pricingPlan: 'FA',

--- a/src/views/onboardingProduct/components/StepAddAdmin.tsx
+++ b/src/views/onboardingProduct/components/StepAddAdmin.tsx
@@ -89,10 +89,6 @@ export function StepAddAdmin({
     }
   };
 
-  const onUserValidateSuccess = (_userId: string, index: number, peopleErrors: UsersError) => {
-    validateUsers(index + 1, peopleErrors);
-  };
-
   const onUserValidateError = (
     userId: string,
     errors: { [fieldName: string]: Array<string> },
@@ -106,11 +102,6 @@ export function StepAddAdmin({
     validateUsers(index + 1, nextPeopleErrors);
   };
 
-  const onUserValidateGenericError = (_userId: string, index: number, peopleErrors: UsersError) => {
-    setGenericError(true);
-    validateUsers(index + 1, peopleErrors);
-  };
-
   const validateUserData = (
     user: UserOnCreate,
     externalInstitutionId: string,
@@ -122,9 +113,8 @@ export function StepAddAdmin({
       externalInstitutionId,
       user,
       prefix,
-      (userId) => onUserValidateSuccess(userId, index, peopleErrors),
+      () => validateUsers(index + 1, peopleErrors),
       (userId, errors) => onUserValidateError(userId, errors, index, peopleErrors),
-      (userId) => onUserValidateGenericError(userId, index, peopleErrors),
       () => setRequiredLogin(true),
       () => {},
       'ONBOARDING_ADD_DELEGATE'


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Fixed the user validation process in the steps of AddManager and AddAdmin

#### Motivation and Context

In the user validation process, for the AddManager and AddAdmin phases, there is an API that checks the validation of the user, who is called Manager or Delegate. If the user is not present in the PDV services, BFF creates the user who can later be indicated as Manager or Delegate for other onboardings. The FE was blocking the process because when the user check is invoked and the user is not found in the PDV services, the API returns the 404 "not found" error and the FE was showing a blocking error.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.