### PR TITLE
[SELC-6587] Feat: Edit "Select your institution" page if there is an empty list for child products

### DIFF
--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -571,6 +571,14 @@ export default {
       helperLink: 'Non trovi il tuo ente? <1>Scopri perché</1>',
       confirmButton: 'Continua',
     },
+    noPartyStep: {
+      title: 'Nessuno dei tuoi enti può <1/> aderire',
+      subTitle:
+        "Se non vedi enti disponibili nella lista, l'ente cercato potrebbe <1/> aver già aderito a <3>{{productName}}</3>",
+      notPartyAvailable: 'Nessun ente disponibile',
+      helperLink: 'Il tuo ente ha aderito ma non è disponibile? <1>Scopri perché</1>',
+      backButton: 'Indietro',
+    },
     genericError: {
       title: 'Qualcosa è andato storto',
       subTitle:
@@ -658,7 +666,8 @@ export default {
       subTitle:
         'Inserisci le informazioni richieste e assicurati che siano corrette.<1 /> Serviranno a registrarti come Partner tecnologico per il<3 /> prodotto <5>{{nameProduct}}</5>.',
     },
-    pspDashboardWarning: 'Per aggiornare i dati presenti, contatta il servizio di <1>Assistenza</1>',
+    pspDashboardWarning:
+      'Per aggiornare i dati presenti, contatta il servizio di <1>Assistenza</1>',
     billingDataSection: {
       invalidFiscalCode: 'Il Codice Fiscale non è valido',
       invalidTaxCodeInvoicing: 'Il Codice Fiscale inserito non è relativo al tuo ente',

--- a/src/views/onboardingPremium/OnboardingPremium.tsx
+++ b/src/views/onboardingPremium/OnboardingPremium.tsx
@@ -38,6 +38,7 @@ import SubProductStepSuccess from './components/SubProductStepSuccess';
 import { SubProductStepSelectUserParty } from './components/SubProductStepSelectUserParty';
 // import SubProductStepSelectPricingPlan from './components/subProductStepPricingPlan/SubProductStepSelectPricingPlan';
 import SubProductStepUserUnrelated from './components/SubProductStepUserUnrelated';
+import { SubProductStepNoParties } from './components/SubProductStepNoParties';
 
 type OnboardingPremiumUrlParams = {
   productId: string;
@@ -147,7 +148,7 @@ function OnboardingPremiumComponent() {
     });
     // eslint-disable-next-line functional/immutable-data
     chooseFromMyParties.current = isUserParty;
-    forward(isUserParty ? 2 : 1);
+    forward(isUserParty ? 3 : 2);
   };
 
   const forwardWithOnboardingData = (
@@ -280,6 +281,10 @@ function OnboardingPremiumComponent() {
             }
           },
         }),
+    },
+    {
+      label: 'Step No Parties',
+      Component: () => SubProductStepNoParties({ subProduct, activeStep, setActiveStep, back: () => window.location.assign(`${ENV.URL_FE.DASHBOARD}/${partyId}`) }),
     },
     {
       label: 'Select Institution unrelated',

--- a/src/views/onboardingPremium/components/SubProductStepNoParties.tsx
+++ b/src/views/onboardingPremium/components/SubProductStepNoParties.tsx
@@ -1,0 +1,125 @@
+import { Grid, Link, Typography, useTheme, Paper } from '@mui/material';
+import { Box } from '@mui/system';
+import { styled } from '@mui/material/styles';
+import { useTranslation, Trans } from 'react-i18next';
+import { SetStateAction } from 'react';
+import { Product } from '../../../../types';
+import { OnboardingStepActions } from '../../../components/OnboardingStepActions';
+
+type Props = {
+  subProduct: Product | undefined;
+  activeStep: number;
+  setActiveStep: (value: SetStateAction<number>) => void;
+  back: () => void;
+};
+
+const CustomBox = styled(Box)({
+  '&::-webkit-scrollbar': {
+    width: 4,
+  },
+  '&::-webkit-scrollbar-track': {
+    boxShadow: `inset 10px 10px  #E6E9F2`,
+  },
+  '&::-webkit-scrollbar-thumb': {
+    backgroundColor: '#0073E6',
+    borderRadius: '16px',
+  },
+  overflowY: 'auto',
+  overflowX: 'hidden',
+});
+export function SubProductStepNoParties({ subProduct, activeStep, setActiveStep, back }: Props) {
+  const { t } = useTranslation();
+
+  const theme = useTheme();
+
+  return (
+    <Grid container direction="column" sx={{ minWidth: '480px' }}>
+      <Grid container item justifyContent="center">
+        <Grid item xs={12}>
+          <Typography variant="h3" component="h2" align="center" color={theme.palette.text.primary}>
+            <Trans i18nKey="onboardingSubProduct.noPartyStep.title" components={{ 1: <br /> }}>
+              {`Nessuno dei tuoi enti può <1/> aderire`}
+            </Trans>
+          </Typography>
+        </Grid>
+      </Grid>
+
+      <Grid container item justifyContent="center" mt={1}>
+        <Grid item xs={12}>
+          <Typography variant="body1" align="center" color={theme.palette.text.primary}>
+            <Trans
+              i18nKey="onboardingSubProduct.noPartyStep.subTitle"
+              values={{ productName: subProduct?.title }}
+              components={{ 1: <br />, 3: <strong /> }}
+            >
+              {`Se non vedi enti disponibili nella lista, l'ente cercato potrebbe <br/> aver già aderito <3>{{productName}}</3>`}
+            </Trans>
+          </Typography>
+        </Grid>
+      </Grid>
+
+      <Grid container item textAlign="center" justifyContent="center" mt={4} mb={2}>
+        <Paper
+          elevation={8}
+          sx={{ borderRadius: theme.spacing(2), py: 2, px: 4, minWidth: '480px' }}
+        >
+          <CustomBox
+            maxHeight={'250px'}
+            sx={{
+              pointerEvents: 'none',
+            }}
+          >
+            <Typography
+              py={2}
+              sx={{
+                fontSize: '18px',
+                fontWeight: 'fontWeightBold',
+                display: 'flex',
+                justifyContent: 'flex-start',
+              }}
+            >
+              {t('onboardingSubProduct.noPartyStep.notPartyAvailable')}
+            </Typography>
+          </CustomBox>
+        </Paper>
+      </Grid>
+
+      <Grid container item justifyContent="center">
+        <Grid item xs={6}>
+          <Box
+            sx={{
+              fontSize: '14px',
+              lineHeight: '24px',
+              textAlign: 'center',
+            }}
+          >
+            <Typography
+              aria-label="Non trovi il tuo ente? Scopri perché"
+              sx={{
+                textAlign: 'center',
+              }}
+              variant="caption"
+              color={theme.palette.text.primary}
+            >
+              <Trans i18nKey="onboardingSubProduct.noPartyStep.helperLink">
+              Non trovi il tuo ente?
+                <Link sx={{ cursor: 'pointer' }} onClick={() => setActiveStep(activeStep + 1)}>
+                  Scopri perché
+                </Link>
+              </Trans>
+            </Typography>
+          </Box>
+        </Grid>
+      </Grid>
+
+      <Grid item mt={3}>
+        <OnboardingStepActions
+          back={{
+            action: back,
+            label: t('onboardingSubProduct.noPartyStep.backButton'),
+          }}
+        />
+      </Grid>
+    </Grid>
+  );
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-6587] Feat: Edit "Select your institution" page if there is an empty list for child products

#### Motivation and Context

In case a user accesses the membership flow of a child product (prod-io-premium, prod-dashboard-psp) via an external link, if the user has no associated entities (the entity has not joined IO, the entity has already joined the child product or the user does not have a role on the product), we currently show the empty list with “no results”.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-6587]: https://pagopa.atlassian.net/browse/SELC-6587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ