### PR TITLE
[SELC-7647] Feat: Add soleTrader field and update onboarding logic for private merchants

### DIFF
--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -36,7 +36,7 @@ import UpdateGeotaxonomy from '../onboardingFormData/taxonomy/UpdateGeotaxonomy'
 import GeoTaxonomySection from '../onboardingFormData/taxonomy/GeoTaxonomySection';
 import { useHistoryState } from '../useHistoryState';
 import { VatNumberErrorModal } from '../onboardingFormData/VatNumberErrorModal';
-import { canInvoice, PRODUCT_IDS, requiredError } from '../../utils/constants';
+import { canInvoice, fiscalCodeRegexp, PRODUCT_IDS, requiredError } from '../../utils/constants';
 import Heading from '../onboardingFormData/Heading';
 import { validateFields } from '../../utils/validateFields';
 import { handleGeotaxonomies } from '../../utils/handleGeotaxonomies';
@@ -524,6 +524,16 @@ export default function StepOnboardingFormData({
       void formik.setFieldValue('istatCode', countries[0].istat_code);
     }
   }, [countries]);
+
+  useEffect(() => {
+    if (
+      isPrivateMerchant &&
+      formik.values.taxCode &&
+      fiscalCodeRegexp.test(formik.values.taxCode)
+    ) {
+      void formik.setFieldValue('soleTrader', true);
+    }
+  }, [formik.values.taxCode]);
 
   const baseTextFieldProps = (
     field: keyof OnboardingFormData,

--- a/src/model/OnboardingFormData.ts
+++ b/src/model/OnboardingFormData.ts
@@ -47,4 +47,5 @@ export type OnboardingFormData = {
   iban?: string;
   confirmIban?: string;
   holder?: string;
+  soleTrader?: boolean;
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -213,13 +213,14 @@ export const commercialRegisterNumberRegexp = new RegExp('^\\d{11}$');
 export const numericField = new RegExp('^[0-9]*$');
 export const currencyField = new RegExp(/^(0|[1-9][0-9]*(?:(,[0-9]*)*|[0-9]*))((\\.|,)[0-9]+)*$/);
 export const onlyCharacters = new RegExp(/^[A-Za-z\s]*$/);
+export const fiscalCodeRegexp = /^[A-Z]{6}[0-9]{2}[A-Z][0-9]{2}[A-Z][0-9A-Z]{3}[A-Z0-9]$/;
 
 export const canInvoice = (institutionType?: string, productId?: string) =>
   institutionType !== 'SA' &&
   institutionType !== 'PT' &&
   institutionType !== 'AS' &&
   productId !== PRODUCT_IDS.INTEROP &&
-  productId !== PRODUCT_IDS.IDPAY_MERCHANT;;
+  productId !== PRODUCT_IDS.IDPAY_MERCHANT;
 
 export const noMandatoryIpaProducts = (productId?: string) =>
   productId !== PRODUCT_IDS.INTEROP &&

--- a/src/utils/test-utils.tsx
+++ b/src/utils/test-utils.tsx
@@ -685,6 +685,7 @@ export const verifySubmit = async (
                 institutionCourtMeasures: true,
               }
             : undefined,
+        soleTrader: isPrivateMerchant && typeOfSearch === 'personalTaxCode' ? true : undefined,
         companyInformations:
           ((from === 'ANAC' ||
             from === 'INFOCAMERE' ||

--- a/src/views/onboardingProduct/OnboardingProduct.tsx
+++ b/src/views/onboardingProduct/OnboardingProduct.tsx
@@ -545,6 +545,7 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
             institutionType === 'PSP'
               ? pspData2pspDataRequest(onboardingFormData as OnboardingFormData)
               : undefined,
+          soleTrader: onboardingFormData?.soleTrader,
           companyInformations:
             onboardingFormData?.businessRegisterPlace ||
             onboardingFormData?.rea ||

--- a/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
+++ b/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
 import '@testing-library/jest-dom';
-import { User } from '../../../../types';
+import { InstitutionType, User } from '../../../../types';
 import { HeaderContext, UserContext } from '../../../lib/context';
 import { ENV } from '../../../utils/env';
 import OnboardingProduct from '../OnboardingProduct';
@@ -37,7 +37,7 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: () => ({
     location: mockedLocation,
-    replace: (nextLocation) => Object.assign(mockedLocation, nextLocation),
+    replace: (nextLocation: any) => Object.assign(mockedLocation, nextLocation),
     push: mockedHistoryPush,
   }),
 }));
@@ -74,7 +74,7 @@ beforeEach(() => {
 
 const filterByCategory4Test = (institutionType?: string, productId?: string) => {
   if (productId === PRODUCT_IDS.SEND) {
-    return mockedCategories.product[PRODUCT_IDS.SEND].ipa.PA;
+    return mockedCategories.product['prod-pn'].ipa.PA;
   } else if (productId === PRODUCT_IDS.IDPAY_MERCHANT) {
     return mockedCategories.product['prod-idpay-merchant']?.merchantDetails?.atecoCodes;
   } else if (institutionType === 'GSP') {
@@ -758,7 +758,7 @@ test('Test: RecipientCode input client validation', async () => {
   expect(recipientCodeInput.value).toBe('AB123CD');
 });
 
-const completeOnboardingPdndInfocamereRequest = async (institutionType) => {
+const completeOnboardingPdndInfocamereRequest = async (institutionType: InstitutionType) => {
   renderComponent(PRODUCT_IDS.INTEROP);
   await executeStepInstitutionType(PRODUCT_IDS.INTEROP, institutionType);
   await executeStepSearchParty(

--- a/src/views/onboardingProduct/components/StepVerifyOnboarding.tsx
+++ b/src/views/onboardingProduct/components/StepVerifyOnboarding.tsx
@@ -21,6 +21,7 @@ import { MessageNoAction } from '../../../components/MessageNoAction';
 import UserNotAllowedPage from '../../UserNotAllowedPage';
 import AlreadyOnboarded from '../../AlreadyOnboarded';
 import { OnboardingFormData } from '../../../model/OnboardingFormData';
+import { fiscalCodeRegexp, PRODUCT_IDS } from '../../../utils/constants';
 
 type Props = StepperStepComponentProps & {
   externalInstitutionId: string;
@@ -116,6 +117,12 @@ export function StepVerifyOnboarding({
           subunitCode: onboardingFormData?.uoUniqueCode ?? onboardingFormData?.aooUniqueCode,
           origin: onboardingFormData?.origin,
           originId: onboardingFormData?.originId,
+          soleTrader:
+            productId === PRODUCT_IDS.IDPAY_MERCHANT &&
+            onboardingFormData?.taxCode &&
+            fiscalCodeRegexp.test(onboardingFormData.taxCode)
+              ? true
+              : undefined,
         },
       },
       () => setRequiredLogin(true)


### PR DESCRIPTION
…r private merchants

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-7647] Feat: Add soleTrader field and update onboarding logic for private merchants

#### Motivation and Context

Add soleTrader field if the party research in the onboarding flow of 'prod-idpay-merchant' it's by personalTaxId
Add soleTrader param in the verifyOnboarding request params

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-7647]: https://pagopa.atlassian.net/browse/SELC-7647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ