### PR TITLE
[SELC-7768] Feat: delete soleTrader field

### DIFF
--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -525,16 +525,6 @@ export default function StepOnboardingFormData({
     }
   }, [countries]);
 
-  useEffect(() => {
-    if (
-      isPrivateMerchant &&
-      formik.values.taxCode &&
-      fiscalCodeRegexp.test(formik.values.taxCode)
-    ) {
-      void formik.setFieldValue('soleTrader', true);
-    }
-  }, [formik.values.taxCode]);
-
   const baseTextFieldProps = (
     field: keyof OnboardingFormData,
     label: string,

--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -36,7 +36,7 @@ import UpdateGeotaxonomy from '../onboardingFormData/taxonomy/UpdateGeotaxonomy'
 import GeoTaxonomySection from '../onboardingFormData/taxonomy/GeoTaxonomySection';
 import { useHistoryState } from '../useHistoryState';
 import { VatNumberErrorModal } from '../onboardingFormData/VatNumberErrorModal';
-import { canInvoice, fiscalCodeRegexp, PRODUCT_IDS, requiredError } from '../../utils/constants';
+import { canInvoice, PRODUCT_IDS, requiredError } from '../../utils/constants';
 import Heading from '../onboardingFormData/Heading';
 import { validateFields } from '../../utils/validateFields';
 import { handleGeotaxonomies } from '../../utils/handleGeotaxonomies';

--- a/src/model/OnboardingFormData.ts
+++ b/src/model/OnboardingFormData.ts
@@ -47,5 +47,4 @@ export type OnboardingFormData = {
   iban?: string;
   confirmIban?: string;
   holder?: string;
-  soleTrader?: boolean;
 };

--- a/src/utils/test-utils.tsx
+++ b/src/utils/test-utils.tsx
@@ -685,7 +685,6 @@ export const verifySubmit = async (
                 institutionCourtMeasures: true,
               }
             : undefined,
-        soleTrader: isPrivateMerchant && typeOfSearch === 'personalTaxCode' ? true : undefined,
         companyInformations:
           ((from === 'ANAC' ||
             from === 'INFOCAMERE' ||

--- a/src/views/onboardingProduct/OnboardingProduct.tsx
+++ b/src/views/onboardingProduct/OnboardingProduct.tsx
@@ -547,7 +547,6 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
             institutionType === 'PSP'
               ? pspData2pspDataRequest(onboardingFormData as OnboardingFormData)
               : undefined,
-          soleTrader: onboardingFormData?.soleTrader,
           companyInformations:
             onboardingFormData?.businessRegisterPlace ||
             onboardingFormData?.rea ||

--- a/src/views/onboardingProduct/components/StepVerifyOnboarding.tsx
+++ b/src/views/onboardingProduct/components/StepVerifyOnboarding.tsx
@@ -21,7 +21,6 @@ import { MessageNoAction } from '../../../components/MessageNoAction';
 import UserNotAllowedPage from '../../UserNotAllowedPage';
 import AlreadyOnboarded from '../../AlreadyOnboarded';
 import { OnboardingFormData } from '../../../model/OnboardingFormData';
-import { fiscalCodeRegexp, PRODUCT_IDS } from '../../../utils/constants';
 
 type Props = StepperStepComponentProps & {
   externalInstitutionId: string;

--- a/src/views/onboardingProduct/components/StepVerifyOnboarding.tsx
+++ b/src/views/onboardingProduct/components/StepVerifyOnboarding.tsx
@@ -117,12 +117,6 @@ export function StepVerifyOnboarding({
           subunitCode: onboardingFormData?.uoUniqueCode ?? onboardingFormData?.aooUniqueCode,
           origin: onboardingFormData?.origin,
           originId: onboardingFormData?.originId,
-          soleTrader:
-            productId === PRODUCT_IDS.IDPAY_MERCHANT &&
-            onboardingFormData?.taxCode &&
-            fiscalCodeRegexp.test(onboardingFormData.taxCode)
-              ? true
-              : undefined,
         },
       },
       () => setRequiredLogin(true)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-7768] Feat: delete soleTrader field

#### Motivation and Context

The soleTrader field is obsolete and its utility will be replaced with the new institutionType PRV_PF for the PARI product onboarding flow searched with the personalTaxCode

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-7768]: https://pagopa.atlassian.net/browse/SELC-7768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ