### PR TITLE
[SELC-7771] Feat: add new institutionType PRV_PF just in case the party is searched by personalTaxCode for the product PARI

### DIFF
--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -36,12 +36,13 @@ export const stepSelectParty = async (page: Page, aggregator?: boolean, party?: 
 export const stepSelectPartyByCF = async (
   page: Page,
   cfParty: string,
-  isPrivateMerchant?: boolean
+  isPrivateMerchant?: boolean,
+  isPrivateMerchantPF?: boolean
 ) => {
   await page.click('#Parties');
   await page.fill('#Parties', cfParty, { timeout: 5000 });
 
-  if (isPrivateMerchant) {
+  if (isPrivateMerchant || isPrivateMerchantPF) {
     const businessTaxIdSelector = `[businesstaxid="${cfParty}"]`;
     await page.waitForSelector(businessTaxIdSelector, { state: 'visible', timeout: 10000 });
     await page.click(`${businessTaxIdSelector} [role="button"]`);

--- a/src/components/autocomplete/Autocomplete.tsx
+++ b/src/components/autocomplete/Autocomplete.tsx
@@ -35,6 +35,8 @@ type AutocompleteProps = {
   setIsPresentInAtecoWhiteList?: Dispatch<SetStateAction<boolean>>;
   setMerchantSearchResult?: Dispatch<SetStateAction<any>>;
   disabledStatusCompany?: boolean;
+  selections: SelectionsState;
+  setSelections: Dispatch<SetStateAction<SelectionsState>>;
 };
 
 export function Autocomplete({
@@ -60,21 +62,13 @@ export function Autocomplete({
   filterCategories,
   setIsPresentInAtecoWhiteList,
   setMerchantSearchResult,
-  disabledStatusCompany
+  disabledStatusCompany,
+  selections,
+  setSelections,
 }: AutocompleteProps) {
   const { t } = useTranslation();
   const [options, setOptions] = useState<Array<InstitutionResource>>([]);
   const [cfResult, setCfResult] = useState<PartyData>();
-
-  const [selections, setSelections] = useState<SelectionsState>({
-    businessName: true,
-    aooCode: false,
-    uoCode: false,
-    reaCode: false,
-    personalTaxCode: false,
-    taxCode: false,
-    ivassCode: false,
-  });
 
   const selectOnly = (field: SelectionEnum) => {
     setSelections({

--- a/src/components/autocomplete/components/partyAdvancedSearchType/PartyAdvancedSelect.tsx
+++ b/src/components/autocomplete/components/partyAdvancedSearchType/PartyAdvancedSelect.tsx
@@ -10,7 +10,7 @@ import { PRODUCT_IDS } from '../../../../utils/constants';
 import { ENV } from '../../../../utils/env';
 
 type Props = {
-  selections: SelectionsState;
+  selections?: SelectionsState;
   setSelected: React.Dispatch<React.SetStateAction<any>>;
   handleSelectionChange: (newSelection: SelectionEnum) => void;
   setOptions: React.Dispatch<React.SetStateAction<Array<any>>>;
@@ -77,8 +77,8 @@ export default function PartyAdvancedSelect({
   }, []);
 
   useEffect(() => {
-    const selectedKey = Object.keys(selections).find(
-      (key) => selections[key as keyof SelectionsState]
+    const selectedKey = Object.keys(selections ?? []).find(
+      (key) => selections && selections[key as keyof SelectionsState]
     );
     if (selectedKey) {
       setTypeOfSearch(selectedKey);

--- a/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
+++ b/src/components/onboardingFormData/PersonalAndBillingDataSection.tsx
@@ -81,6 +81,7 @@ type Props = StepperStepComponentProps & {
   isForeignInsurance?: boolean;
   isPdndPrivate: boolean;
   isPrivateMerchant: boolean;
+  isPrivateMerchantPF: boolean;
   setInvalidTaxCodeInvoicing: React.Dispatch<React.SetStateAction<boolean>>;
   recipientCodeStatus?: string;
   getCountriesFromGeotaxonomies: (
@@ -111,6 +112,7 @@ export default function PersonalAndBillingDataSection({
   productId,
   isPdndPrivate,
   isPrivateMerchant,
+  isPrivateMerchantPF,
   setInvalidTaxCodeInvoicing,
   recipientCodeStatus,
   getCountriesFromGeotaxonomies,
@@ -773,7 +775,7 @@ export default function PersonalAndBillingDataSection({
             {formik.values.hasVatnumber &&
               (!isInsuranceCompany ||
                 (onboardingFormData?.taxCode && onboardingFormData?.taxCode !== '')) &&
-              !isPrivateMerchant && (
+              (!isPrivateMerchant || !isPrivateMerchantPF) && (
                 <Grid item>
                   <Box display="flex" alignItems="center">
                     <Checkbox
@@ -800,7 +802,7 @@ export default function PersonalAndBillingDataSection({
               )}
             {productId !== PRODUCT_IDS.FD &&
               productId !== PRODUCT_IDS.FD_GARANTITO &&
-              !isPrivateMerchant && (
+              (!isPrivateMerchant || !isPrivateMerchantPF) && (
                 <Grid item>
                   <Box
                     display="flex"
@@ -855,7 +857,12 @@ export default function PersonalAndBillingDataSection({
                     : theme.palette.text.primary
                 )}
                 value={formik.values.vatNumber}
-                disabled={stepHistoryState.isTaxCodeEquals2PIVA || isPremium || isPrivateMerchant}
+                disabled={
+                  stepHistoryState.isTaxCodeEquals2PIVA ||
+                  isPremium ||
+                  isPrivateMerchant ||
+                  isPrivateMerchantPF
+                }
                 onClick={() => setShrinkVatNumber(true)}
                 onBlur={() => setShrinkVatNumber(false)}
                 InputLabelProps={{
@@ -988,7 +995,8 @@ export default function PersonalAndBillingDataSection({
             productId === PRODUCT_IDS.PAGOPA ||
             productId === PRODUCT_IDS.IDPAY_MERCHANT) &&
             (institutionType === 'SCP' ||
-              institutionType === 'PRV' ||
+              institutionType === 'PRV' || 
+              institutionType === 'PRV_PF' ||
               institutionType === 'GPU'))) && (
           <>
             <Grid item xs={12}>
@@ -997,7 +1005,10 @@ export default function PersonalAndBillingDataSection({
                 paddingValue={isContractingAuthority ? '20px' : '24px'}
                 {...baseTextFieldProps(
                   'businessRegisterPlace',
-                  isContractingAuthority || isPdndPrivate || isPrivateMerchant
+                  isContractingAuthority ||
+                    isPdndPrivate ||
+                    isPrivateMerchant ||
+                    isPrivateMerchantPF
                     ? t(
                         'onboardingFormData.billingDataSection.informationCompanies.requiredCommercialRegisterNumber'
                       )

--- a/src/components/onboardingFormData/__tests__/PersonalAndBillingDataSection.test.tsx
+++ b/src/components/onboardingFormData/__tests__/PersonalAndBillingDataSection.test.tsx
@@ -43,7 +43,7 @@ const mockFormik = {
 
 (useFormik as jest.Mock).mockReturnValue(mockFormik);
 
-const formik = {
+const formik: any = {
   values: {
     businessName: '',
     zipCode: '12345',
@@ -92,9 +92,9 @@ const mockBaseTextFieldProps = (
 
 test('Test: Rendered PersonalAndBillingDataSection component with all possible business cases', () => {
   let componentRendered = false;
-  const conditionsMap = {};
-  let onboardingFormData;
-  let productId;
+  const conditionsMap = {} as any;
+  let onboardingFormData: any;
+  let productId: string;
 
   mockedProducts.forEach((product) => {
     institutionTypes.forEach((institutionType) => {
@@ -134,6 +134,7 @@ test('Test: Rendered PersonalAndBillingDataSection component with all possible b
         const isPrivateParty = productId === PRODUCT_IDS.INTEROP && institutionType === 'PRV';
         const isPdndPrivate = productId === PRODUCT_IDS.INTEROP && institutionType === 'PRV';
         const isPrivateMerchant = productId === PRODUCT_IDS.IDPAY_MERCHANT && institutionType === 'PRV';
+        const isPrivateMerchantPF = productId === PRODUCT_IDS.IDPAY_MERCHANT && institutionType === 'PRV_PF';
 
         conditionsMap[`${productId}-${institutionType}`] = {
           isPremium,
@@ -143,7 +144,8 @@ test('Test: Rendered PersonalAndBillingDataSection component with all possible b
           institutionAvoidGeotax,
           isInsuranceCompany,
           isPrivateParty,
-          isPrivateMerchant
+          isPrivateMerchant,
+          isPrivateMerchantPF
         };
 
         renderComponentWithProviders(
@@ -171,6 +173,7 @@ test('Test: Rendered PersonalAndBillingDataSection component with all possible b
             countries={undefined}
             setCountries={jest.fn()}
             isPrivateMerchant={isPrivateMerchant}
+            isPrivateMerchantPF={isPrivateMerchantPF}
           />
         );
 
@@ -186,7 +189,8 @@ test('Test: Rendered PersonalAndBillingDataSection component with all possible b
       isForeignInsurance,
       institutionAvoidGeotax,
       isPrivateParty,
-      isPrivateMerchant
+      isPrivateMerchant,
+      isPrivateMerchantPF
     } = conditionsMap[key];
 
     const centralParty = screen.queryByText('Ente centrale');
@@ -293,7 +297,7 @@ test('Test: Rendered PersonalAndBillingDataSection component with all possible b
       expect(shareCapital).not.toBeInTheDocument();
     }
 
-    if(isPrivateMerchant) {
+    if(isPrivateMerchant || isPrivateMerchantPF) {
       expect(iban).toBeInTheDocument();
       expect(confirmIban).toBeInTheDocument();
       expect(holder).toBeInTheDocument();

--- a/src/components/steps/StepOnboardingFormData.tsx
+++ b/src/components/steps/StepOnboardingFormData.tsx
@@ -130,9 +130,12 @@ export default function StepOnboardingFormData({
   const isPaymentServiceProvider = institutionType === 'PSP';
   const isPdndPrivate = institutionType === 'PRV' && productId === PRODUCT_IDS.INTEROP;
   const isPrivateMerchant = institutionType === 'PRV' && productId === PRODUCT_IDS.IDPAY_MERCHANT;
+  const isPrivateMerchantPF =
+    institutionType === 'PRV_PF' && productId === PRODUCT_IDS.IDPAY_MERCHANT;
   const isInformationCompany =
     origin !== 'IPA' &&
     institutionType !== 'PRV' &&
+    institutionType !== 'PRV_PF' &&
     (institutionType === 'GSP' || institutionType === 'SCP') &&
     (productId === PRODUCT_IDS.IO ||
       productId === PRODUCT_IDS.IO_SIGN ||
@@ -326,6 +329,7 @@ export default function StepOnboardingFormData({
         invalidTaxCodeInvoicing,
         isPdndPrivate,
         isPrivateMerchant,
+        isPrivateMerchantPF,
         recipientCodeStatus,
         productId
       )
@@ -476,7 +480,7 @@ export default function StepOnboardingFormData({
       formik.values.taxCode === formik.values.vatNumber &&
       formik.values.taxCode &&
       formik.values.taxCode.length > 0 &&
-      !isPrivateMerchant
+      (!isPrivateMerchant || !isPrivateMerchantPF)
     ) {
       setStepHistoryState({
         ...stepHistoryState,
@@ -597,13 +601,14 @@ export default function StepOnboardingFormData({
           isInvoiceable={isInvoiceable}
           isPdndPrivate={isPdndPrivate}
           isPrivateMerchant={isPrivateMerchant}
+          isPrivateMerchantPF={isPrivateMerchantPF}
           setInvalidTaxCodeInvoicing={setInvalidTaxCodeInvoicing}
           recipientCodeStatus={recipientCodeStatus}
           getCountriesFromGeotaxonomies={getCountriesFromGeotaxonomies}
           countries={countries}
           setCountries={setCountries}
         />
-        {isPrivateMerchant && (
+        {(isPrivateMerchant || isPrivateMerchantPF) && (
           <IbanSection baseTextFieldProps={baseTextFieldProps} formik={formik} />
         )}
         {!institutionAvoidGeotax && subProductId !== PRODUCT_IDS.DASHBOARD_PSP && (

--- a/src/utils/selected2OnboardingData.ts
+++ b/src/utils/selected2OnboardingData.ts
@@ -18,7 +18,8 @@ export const selected2OnboardingData = (
   aooName: selectedParty?.denominazioneAoo,
   atecoCodes: selectedParty?.atecoCodes,
   legalForm:
-    institutionType === 'PRV' && productId === PRODUCT_IDS.IDPAY_MERCHANT
+    (institutionType === 'PRV' && productId === PRODUCT_IDS.IDPAY_MERCHANT) ||
+    (institutionType === 'PRV_PF' && productId === PRODUCT_IDS.IDPAY_MERCHANT)
       ? selectedParty?.legalForm
       : undefined,
   uoName: selectedParty?.descrizioneUo,
@@ -48,7 +49,7 @@ export const selected2OnboardingData = (
       ? selectedParty?.businessTaxId
       : (selectedParty?.codiceUniUo ?? selectedParty?.codiceUniAoo ?? selectedParty?.originId),
   origin:
-    (institutionType === 'PRV' &&
+    ((institutionType === 'PRV' || institutionType === 'PRV_PF') &&
       (productId === PRODUCT_IDS.INTEROP || productId === PRODUCT_IDS.IDPAY_MERCHANT)) ||
     institutionType === 'SCP'
       ? 'PDND_INFOCAMERE'

--- a/src/utils/test-utils.tsx
+++ b/src/utils/test-utils.tsx
@@ -349,11 +349,13 @@ export const billingData2billingDataRequest = (
   // eslint-disable-next-line sonarjs/cognitive-complexity
 ) => {
   const isPrivateMerchant = institutionType === 'PRV' && productId === PRODUCT_IDS.IDPAY_MERCHANT;
+  const isPrivateMerchantPF =
+    institutionType === 'PRV_PF' && productId === PRODUCT_IDS.IDPAY_MERCHANT;
 
   return {
     businessName: errorOnSubmit
       ? mockPartyRegistry.items[1].description
-      : isPrivateMerchant && typeOfSearch === 'personalTaxCode'
+      : isPrivateMerchantPF
         ? mockedPdndVisuraInfomacere[5].businessName
         : isPrivateMerchant && typeOfSearch === 'taxCode'
           ? mockedPdndVisuraInfomacere[0].businessName
@@ -395,7 +397,7 @@ export const billingData2billingDataRequest = (
 
     digitalAddress: errorOnSubmit
       ? mockPartyRegistry.items[1].digitalAddress
-      : isPrivateMerchant && typeOfSearch === 'personalTaxCode'
+      : isPrivateMerchantPF
         ? mockedPdndVisuraInfomacere[5].digitalAddress
         : isPrivateMerchant && typeOfSearch === 'taxCode'
           ? mockedPdndVisuraInfomacere[0].digitalAddress
@@ -439,7 +441,7 @@ export const billingData2billingDataRequest = (
 
     taxCode: errorOnSubmit
       ? mockPartyRegistry.items[1].taxCode
-      : isPrivateMerchant && typeOfSearch === 'personalTaxCode'
+      : isPrivateMerchantPF
         ? mockedPdndVisuraInfomacere[5].businessTaxId
         : isPrivateMerchant && typeOfSearch === 'taxCode'
           ? mockedPdndVisuraInfomacere[0].businessTaxId
@@ -467,7 +469,7 @@ export const billingData2billingDataRequest = (
 
     vatNumber: errorOnSubmit
       ? mockPartyRegistry.items[1].taxCode
-      : isPrivateMerchant
+      : isPrivateMerchant || isPrivateMerchantPF
         ? mockedPdndVisuraInfomacere[0].businessTaxId
         : from === 'INFOCAMERE' || from === 'PDND_INFOCAMERE'
           ? mockedPartiesFromInfoCamere[0].businessTaxId
@@ -495,26 +497,26 @@ export const billingData2billingDataRequest = (
           : '87654321098'
       : undefined,
 
-    recipientCode: isPrivateMerchant
-      ? undefined
-      : errorOnSubmit
-        ? 'A2B3C4'
-        : institutionType === 'PSP'
-          ? 'A1B2C3'
-          : (from === 'IPA' ||
-                institutionType === 'GSP' ||
-                (from === 'NO_IPA' && institutionType === 'GPU')) &&
-              typeOfSearch !== 'aooCode'
-            ? typeOfSearch === 'taxCode'
-              ? 'A3B4C5'
-              : 'A1B2C3'
-            : undefined,
-    legalForm:
-      isPrivateMerchant && typeOfSearch === 'personalTaxCode'
-        ? mockedPdndVisuraInfomacere[5].legalForm
-        : isPrivateMerchant && typeOfSearch === 'taxCode'
-          ? mockedPdndVisuraInfomacere[0].legalForm
-          : undefined,
+    recipientCode:
+      isPrivateMerchant || isPrivateMerchantPF
+        ? undefined
+        : errorOnSubmit
+          ? 'A2B3C4'
+          : institutionType === 'PSP'
+            ? 'A1B2C3'
+            : (from === 'IPA' ||
+                  institutionType === 'GSP' ||
+                  (from === 'NO_IPA' && institutionType === 'GPU')) &&
+                typeOfSearch !== 'aooCode'
+              ? typeOfSearch === 'taxCode'
+                ? 'A3B4C5'
+                : 'A1B2C3'
+              : undefined,
+    legalForm: isPrivateMerchantPF
+      ? mockedPdndVisuraInfomacere[5].legalForm
+      : isPrivateMerchant && typeOfSearch === 'taxCode'
+        ? mockedPdndVisuraInfomacere[0].legalForm
+        : undefined,
   };
 };
 
@@ -532,6 +534,8 @@ export const verifySubmit = async (
   // eslint-disable-next-line sonarjs/cognitive-complexity
 ) => {
   const isPrivateMerchant = institutionType === 'PRV' && productId === PRODUCT_IDS.IDPAY_MERCHANT;
+  const isPrivateMerchantPF =
+    institutionType === 'PRV_PF' && productId === PRODUCT_IDS.IDPAY_MERCHANT;
   const SfeAvailable = (uo || institutionType === 'PA') && canInvoice(institutionType, productId);
 
   // eslint-disable-next-line functional/immutable-data
@@ -551,12 +555,11 @@ export const verifySubmit = async (
           haveTaxCode,
           productId
         ),
-        atecoCodes:
-          isPrivateMerchant && typeOfSearch === 'personalTaxCode'
-            ? mockedPdndVisuraInfomacere[5].atecoCodes
-            : isPrivateMerchant && typeOfSearch === 'taxCode'
-              ? mockedPdndVisuraInfomacere[0].atecoCodes
-              : undefined,
+        atecoCodes: isPrivateMerchantPF
+          ? mockedPdndVisuraInfomacere[5].atecoCodes
+          : isPrivateMerchant && typeOfSearch === 'taxCode'
+            ? mockedPdndVisuraInfomacere[0].atecoCodes
+            : undefined,
         institutionType,
         productId,
         origin:
@@ -583,49 +586,49 @@ export const verifySubmit = async (
                       : undefined,
         originId: errorOnSubmit
           ? mockPartyRegistry.items[1].originId
-          : isPrivateMerchant
-            ? typeOfSearch === 'personalTaxCode'
-              ? mockedPdndVisuraInfomacere[5].businessTaxId
-              : mockedPdndVisuraInfomacere[0].businessTaxId
-            : from === 'NO_IPA'
-              ? mockPartyRegistry.items[0].taxCode
-              : from === 'ANAC'
-                ? mockedANACParties[0].originId
-                : from === 'IVASS'
-                  ? haveTaxCode
-                    ? isForeignInsurance
-                      ? mockedInsuranceResource.items[0].originId
-                      : mockedInsuranceResource.items[2].originId
-                    : mockedInsuranceResource.items[4].originId
-                  : from === 'INFOCAMERE'
-                    ? undefined
-                    : from === 'PDND_INFOCAMERE'
-                      ? '00112233445'
-                      : from === 'SELC'
-                        ? mockPartyRegistry.items[0].taxCode
-                        : typeOfSearch === 'taxCode'
-                          ? mockedParties[0].originId
-                          : typeOfSearch === 'aooCode'
-                            ? mockedAoos[0].codiceUniAoo
-                            : typeOfSearch === 'uoCode'
-                              ? mockedUos[0].codiceUniUo
-                              : (institutionType === 'PT' ||
-                                    institutionType === 'GPU' ||
-                                    institutionType === 'GSP') &&
-                                  productId === PRODUCT_IDS.PAGOPA
-                                ? '991'
-                                : productId === PRODUCT_IDS.PAGOPA && institutionType === 'PRV'
-                                  ? mockPartyRegistry.items[0].taxCode
-                                  : institutionType === 'GPU' &&
-                                      (productId === PRODUCT_IDS.INTEROP ||
-                                        productId === PRODUCT_IDS.IO_SIGN ||
-                                        productId === PRODUCT_IDS.IO)
-                                    ? undefined
-                                    : '991',
+          : isPrivateMerchantPF
+            ? mockedPdndVisuraInfomacere[5].businessTaxId
+            : isPrivateMerchant
+              ? mockedPdndVisuraInfomacere[0].businessTaxId
+              : from === 'NO_IPA'
+                ? mockPartyRegistry.items[0].taxCode
+                : from === 'ANAC'
+                  ? mockedANACParties[0].originId
+                  : from === 'IVASS'
+                    ? haveTaxCode
+                      ? isForeignInsurance
+                        ? mockedInsuranceResource.items[0].originId
+                        : mockedInsuranceResource.items[2].originId
+                      : mockedInsuranceResource.items[4].originId
+                    : from === 'INFOCAMERE'
+                      ? undefined
+                      : from === 'PDND_INFOCAMERE'
+                        ? '00112233445'
+                        : from === 'SELC'
+                          ? mockPartyRegistry.items[0].taxCode
+                          : typeOfSearch === 'taxCode'
+                            ? mockedParties[0].originId
+                            : typeOfSearch === 'aooCode'
+                              ? mockedAoos[0].codiceUniAoo
+                              : typeOfSearch === 'uoCode'
+                                ? mockedUos[0].codiceUniUo
+                                : (institutionType === 'PT' ||
+                                      institutionType === 'GPU' ||
+                                      institutionType === 'GSP') &&
+                                    productId === PRODUCT_IDS.PAGOPA
+                                  ? '991'
+                                  : productId === PRODUCT_IDS.PAGOPA && institutionType === 'PRV'
+                                    ? mockPartyRegistry.items[0].taxCode
+                                    : institutionType === 'GPU' &&
+                                        (productId === PRODUCT_IDS.INTEROP ||
+                                          productId === PRODUCT_IDS.IO_SIGN ||
+                                          productId === PRODUCT_IDS.IO)
+                                      ? undefined
+                                      : '991',
         istatCode: from !== 'IPA' ? mockedGeoTaxonomy[1].istat_code : undefined,
         taxCode: errorOnSubmit
           ? mockPartyRegistry.items[1].taxCode
-          : isPrivateMerchant && typeOfSearch === 'personalTaxCode'
+          : isPrivateMerchantPF
             ? mockedPdndVisuraInfomacere[5].businessTaxId
             : isPrivateMerchant && typeOfSearch === 'taxCode'
               ? mockedPdndVisuraInfomacere[0].businessTaxId
@@ -692,11 +695,12 @@ export const verifySubmit = async (
             ((institutionType === 'GSP' || institutionType === 'GPU') && from !== 'IPA')) &&
             institutionType !== 'PT') ||
           (institutionType === 'PRV' && productId === PRODUCT_IDS.PAGOPA) ||
-          isPrivateMerchant
+          isPrivateMerchant ||
+          isPrivateMerchantPF
             ? {
                 businessRegisterPlace:
                   from === 'ANAC' ||
-                  (institutionType === 'PRV' &&
+                  ((institutionType === 'PRV' || institutionType === 'PRV_PF') &&
                     (productId === PRODUCT_IDS.PAGOPA ||
                       productId === PRODUCT_IDS.INTEROP ||
                       productId === PRODUCT_IDS.IDPAY_MERCHANT))
@@ -709,7 +713,7 @@ export const verifySubmit = async (
                     : undefined,
                 rea:
                   from === 'INFOCAMERE' || from === 'PDND_INFOCAMERE'
-                    ? isPrivateMerchant && typeOfSearch === 'personalTaxCode'
+                    ? isPrivateMerchantPF
                       ? mockedPdndVisuraInfomacere[5].nRea
                       : isPrivateMerchant && typeOfSearch === 'taxCode'
                         ? mockedPdndVisuraInfomacere[0].nRea
@@ -1006,8 +1010,15 @@ export const fillUserBillingDataForm = async (
   // eslint-disable-next-line sonarjs/cognitive-complexity
 ) => {
   const isPrivateMerchant = institutionType === 'PRV' && productId === PRODUCT_IDS.IDPAY_MERCHANT;
+  const isPrivateMerchantPF =
+    institutionType === 'PRV_PF' && productId === PRODUCT_IDS.IDPAY_MERCHANT;
 
-  if (from !== 'IPA' && from !== 'INFOCAMERE' && from !== 'PDND_INFOCAMERE' && !isPrivateMerchant) {
+  if (
+    from !== 'IPA' &&
+    from !== 'INFOCAMERE' &&
+    from !== 'PDND_INFOCAMERE' &&
+    (!isPrivateMerchant || !isPrivateMerchantPF)
+  ) {
     if (institutionType !== 'SA' && institutionType !== 'AS') {
       fireEvent.change(document.getElementById(businessNameInput) as HTMLElement, {
         target: { value: 'businessNameInput' },
@@ -1099,7 +1110,7 @@ export const fillUserBillingDataForm = async (
       fireEvent.change(document.getElementById('businessRegisterPlace') as HTMLElement, {
         target: { value: '01234567891' },
       });
-    } else if (isPrivateMerchant) {
+    } else if (isPrivateMerchant || isPrivateMerchantPF) {
       const personalIndex = typeOfSearch === 'personalTaxCode' ? 5 : 0;
       fireEvent.change(document.getElementById('businessRegisterPlace') as HTMLElement, {
         target: { value: 'Comune' },
@@ -1190,7 +1201,7 @@ export const fillUserBillingDataForm = async (
       }
     }
 
-    if (!isPrivateMerchant) {
+    if (!isPrivateMerchant && !isPrivateMerchantPF) {
       const isTaxCodeEquals2PIVA = document.getElementById(
         'taxCodeEquals2VatNumber'
       ) as HTMLElement;
@@ -1203,7 +1214,7 @@ export const fillUserBillingDataForm = async (
     }
   }
 
-  if (isPrivateMerchant) {
+  if (isPrivateMerchant || isPrivateMerchantPF) {
     fireEvent.change(document.getElementById(vatNumber) as HTMLElement, {
       target: { value: mockedPdndVisuraInfomacere[0].vatNumber },
     });
@@ -1222,7 +1233,7 @@ export const fillUserBillingDataForm = async (
   const abiCode = document.getElementById('abiCode') as HTMLElement;
   const dpoDataSection = document.getElementById('dpo-data-section') as HTMLElement;
 
-  if (institutionType === 'PSP' && !isPrivateMerchant) {
+  if (institutionType === 'PSP' && !isPrivateMerchant && !isPrivateMerchantPF) {
     expect(dpoDataSection).toBeInTheDocument();
     expect(vatNumberGroup).toBeInTheDocument();
     fireEvent.click(vatNumberGroup);
@@ -1293,6 +1304,7 @@ export const fillUserBillingDataForm = async (
 
   if (
     !isPrivateMerchant &&
+    !isPrivateMerchantPF &&
     ((institutionType === 'PA' && !isAoo) || institutionType === 'GSP' || institutionType === 'PSP')
   ) {
     fireEvent.change(document.getElementById(recipientCode) as HTMLElement, {
@@ -1324,6 +1336,8 @@ export const checkCorrectBodyBillingData = (
   // eslint-disable-next-line sonarjs/cognitive-complexity
 ) => {
   const isPrivateMerchant = institutionType === 'PRV' && productId === PRODUCT_IDS.IDPAY_MERCHANT;
+  const isPrivateMerchantPF =
+    institutionType === 'PRV_PF' && productId === PRODUCT_IDS.IDPAY_MERCHANT;
 
   expect((document.getElementById('businessName') as HTMLInputElement).value).toBe(
     institutionType === 'SA'
@@ -1334,9 +1348,10 @@ export const checkCorrectBodyBillingData = (
             ? mockedInsuranceResource.items[0].description
             : mockedInsuranceResource.items[2].description
           : mockedInsuranceResource.items[4].description
-        : institutionType === 'SCP' || (institutionType === 'PRV' && !isPrivateMerchant)
+        : institutionType === 'SCP' ||
+            (institutionType === 'PRV' && !isPrivateMerchant && !isPrivateMerchantPF)
           ? mockedPartiesFromInfoCamere[0].businessName
-          : isPrivateMerchant
+          : isPrivateMerchant || isPrivateMerchantPF
             ? 'Rossi Costruzioni S.r.l.'
             : expectedBusinessName
   );
@@ -1350,9 +1365,10 @@ export const checkCorrectBodyBillingData = (
             ? mockedInsuranceResource.items[0].digitalAddress
             : mockedInsuranceResource.items[2].digitalAddress
           : mockedInsuranceResource.items[4].digitalAddress
-        : institutionType === 'SCP' || (institutionType === 'PRV' && !isPrivateMerchant)
+        : institutionType === 'SCP' ||
+            (institutionType === 'PRV' && !isPrivateMerchant && !isPrivateMerchantPF)
           ? mockedPartiesFromInfoCamere[0].digitalAddress
-          : isPrivateMerchant
+          : isPrivateMerchant || isPrivateMerchantPF
             ? 'rossi.costruzioni@pec.it'
             : expectedMailPEC
   );
@@ -1365,9 +1381,10 @@ export const checkCorrectBodyBillingData = (
           ? isForeignInsurance
             ? mockedInsuranceResource.items[0].taxCode
             : mockedInsuranceResource.items[2].taxCode
-          : institutionType === 'SCP' || (institutionType === 'PRV' && !isPrivateMerchant)
+          : institutionType === 'SCP' ||
+              (institutionType === 'PRV' && !isPrivateMerchant && !isPrivateMerchantPF)
             ? mockedPartiesFromInfoCamere[0].businessTaxId
-            : isPrivateMerchant
+            : isPrivateMerchant || isPrivateMerchantPF
               ? '12345678901'
               : expectedTaxCode
     );
@@ -1378,31 +1395,34 @@ export const checkCorrectBodyBillingData = (
     expect((document.getElementById('country-select') as HTMLInputElement).value).toBe('Spagna');
   } else {
     expect((document.getElementById('zipCode') as HTMLInputElement).value).toBe(
-      institutionType === 'SCP' || (institutionType === 'PRV' && !isPrivateMerchant)
+      institutionType === 'SCP' ||
+        (institutionType === 'PRV' && !isPrivateMerchant && !isPrivateMerchantPF)
         ? mockedPartiesFromInfoCamere[0].zipCode
-        : isPrivateMerchant
+        : isPrivateMerchant || isPrivateMerchantPF
           ? '09010'
           : expectedZipCode
     );
 
-    if (!isPrivateMerchant) {
+    if (!isPrivateMerchant && !isPrivateMerchantPF) {
       expect((document.getElementById('vatNumber') as HTMLInputElement).value).toBe(
         expectedVatNumber
       );
     }
 
     expect((document.getElementById('city-select') as HTMLInputElement).value).toBe(
-      institutionType === 'SCP' || (institutionType === 'PRV' && !isPrivateMerchant)
+      institutionType === 'SCP' ||
+        (institutionType === 'PRV' && !isPrivateMerchant && !isPrivateMerchantPF)
         ? mockedPartiesFromInfoCamere[0].city
-        : isPrivateMerchant
+        : isPrivateMerchant || isPrivateMerchantPF
           ? 'Milano'
           : expectedCity
     );
 
     expect((document.getElementById('county') as HTMLInputElement).value).toBe(
-      institutionType === 'SCP' || (institutionType === 'PRV' && !isPrivateMerchant)
+      institutionType === 'SCP' ||
+        (institutionType === 'PRV' && !isPrivateMerchant && !isPrivateMerchantPF)
         ? mockedPartiesFromInfoCamere[0].county
-        : isPrivateMerchant
+        : isPrivateMerchant || isPrivateMerchantPF
           ? 'MO'
           : expectedCounty
     );
@@ -1410,6 +1430,7 @@ export const checkCorrectBodyBillingData = (
 
   if (
     !isPrivateMerchant &&
+    !isPrivateMerchantPF &&
     (institutionType === 'PA' || institutionType === 'GSP' || institutionType === 'PSP')
   ) {
     expect((document.getElementById('recipientCode') as HTMLInputElement).value).toBe(
@@ -1417,7 +1438,7 @@ export const checkCorrectBodyBillingData = (
     );
   }
 
-  if (isPrivateMerchant) {
+  if (isPrivateMerchant || isPrivateMerchantPF) {
     expect((document.getElementById('businessRegisterPlace') as HTMLInputElement).value).toBe(
       '01234567891'
     );

--- a/src/utils/validateFields.ts
+++ b/src/utils/validateFields.ts
@@ -94,8 +94,13 @@ const validateCountry = (values: Partial<OnboardingFormData>, institutionType: I
   return undefined;
 };
 
-const validateIban = (iban: string | undefined, isPrivateMerchant: boolean, t: TFunction) => {
-  if (isPrivateMerchant && !iban) {
+const validateIban = (
+  iban: string | undefined,
+  isPrivateMerchant: boolean,
+  isPrivateMerchantPF: boolean,
+  t: TFunction
+) => {
+  if ((isPrivateMerchant || isPrivateMerchantPF) && !iban) {
     return requiredError;
   }
   if (iban?.length === IBAN_LENGTH && !ITALIAN_IBAN_REGEX.test(iban)) {
@@ -108,14 +113,15 @@ const validateConfirmIban = (
   confirmIban: string | undefined,
   originalIban: string | undefined,
   isPrivateMerchant: boolean,
+  isPrivateMerchantPF: boolean,
   t: TFunction
 ) => {
-  if (isPrivateMerchant && !confirmIban) {
+  if ((isPrivateMerchant || isPrivateMerchantPF) && !confirmIban) {
     return requiredError;
   }
 
   if (
-    isPrivateMerchant &&
+    (isPrivateMerchant || isPrivateMerchantPF) &&
     confirmIban &&
     confirmIban.length > 0 &&
     confirmIban.length < IBAN_LENGTH
@@ -222,11 +228,12 @@ export const validateFields = (
   invalidTaxCodeInvoicing: boolean,
   isPdndPrivate: boolean,
   isPrivateMerchant: boolean,
+  isPrivateMerchantPF: boolean,
   recipientCodeStatus?: string,
   productId?: string
 ) => {
-  const isRequiredForInfoCompany = isInformationCompany || isPdndPrivate || isPrivateMerchant;
-  const isRequiredForSaOrPrivate = institutionType === 'SA' || isPdndPrivate || isPrivateMerchant;
+  const isRequiredForInfoCompany = isInformationCompany || isPdndPrivate || isPrivateMerchant || isPrivateMerchantPF;
+  const isRequiredForSaOrPrivate = institutionType === 'SA' || isPdndPrivate || isPrivateMerchant || isPrivateMerchantPF;
   const validationRules = {
     businessName: validateConditionalRequired(values.businessName, true),
     registeredOffice: validateConditionalRequired(values.registeredOffice, true),
@@ -239,8 +246,8 @@ export const validateFields = (
     digitalAddress: validateEmail(values.digitalAddress, t),
     originId: validateConditionalRequired(values.originId, institutionType === 'AS'),
     holder: validateConditionalRequired(values.holder, isPrivateMerchant),
-    iban: validateIban(values.iban, isPrivateMerchant, t),
-    confirmIban: validateConfirmIban(values.confirmIban, values.iban, isPrivateMerchant, t),
+    iban: validateIban(values.iban, isPrivateMerchant, isPrivateMerchantPF, t),
+    confirmIban: validateConfirmIban(values.confirmIban, values.iban, isPrivateMerchant, isPrivateMerchantPF, t),
     businessRegisterPlace: validateConditionalRequired(
       values.businessRegisterPlace,
       isRequiredForSaOrPrivate

--- a/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
+++ b/src/views/onboardingProduct/__tests__/OnboardingProduct.test.tsx
@@ -577,7 +577,7 @@ test('Test: Successfull complete onboarding request of PRV party for prod-idpay-
     undefined,
     'MI-123456'
   );
-  await executeStepBillingData(PRODUCT_IDS.IDPAY_MERCHANT, 'PRV', false, false, 'SELC');
+  await executeStepBillingData(PRODUCT_IDS.IDPAY_MERCHANT, 'PRV', false, false, 'PDND_INFOCAMERE');
   await executeStepAddManager(false);
   await executeStepAddAdmin(true, false, false, false, false);
   await verifySubmit(
@@ -592,7 +592,7 @@ test('Test: Successfull complete onboarding request of PRV party for prod-idpay-
   await executeGoHome(mockedLocation);
 });
 
-test('Test: Successfull complete onboarding request of PRV party for prod-idpay-merchant search by personalTaxCode', async () => {
+test('Test: Successfull complete onboarding request of PRV_PF party for prod-idpay-merchant search by personalTaxCode', async () => {
   renderComponent(PRODUCT_IDS.IDPAY_MERCHANT);
   await executeStepInstitutionType(PRODUCT_IDS.IDPAY_MERCHANT, 'PRV');
   await executeStepSearchParty(
@@ -608,7 +608,7 @@ test('Test: Successfull complete onboarding request of PRV party for prod-idpay-
   );
   await executeStepBillingData(
     PRODUCT_IDS.IDPAY_MERCHANT,
-    'PRV',
+    'PRV_PF',
     false,
     false,
     'PDND_INFOCAMERE',
@@ -621,7 +621,7 @@ test('Test: Successfull complete onboarding request of PRV party for prod-idpay-
   await executeStepAddAdmin(true, false, false, false, false);
   await verifySubmit(
     PRODUCT_IDS.IDPAY_MERCHANT,
-    'PRV',
+    'PRV_PF',
     fetchWithLogsSpy,
     'PDND_INFOCAMERE',
     false,
@@ -946,9 +946,7 @@ const executeStepSearchParty = async (
         fireEvent.change(inputPartyName, { target: { value: 'RSSLCU80A01F205N' } });
 
         expect(
-          screen.getByText(
-            'Il codice ATECO inserito non è ammesso per l’adesione al portale'
-          )
+          screen.getByText('Il codice ATECO inserito non è ammesso per l’adesione al portale')
         ).toBeInTheDocument();
 
         fireEvent.change(inputPartyName, { target: { value: 'FRSMRA70D30G786G' } });
@@ -1124,6 +1122,8 @@ const executeStepBillingData = async (
   await waitFor(() => screen.getByText('Inserisci i dati dell’ente'));
 
   const isPrivateMerchant = institutionType === 'PRV' && productId === PRODUCT_IDS.IDPAY_MERCHANT;
+  const isPrivateMerchantPF =
+    institutionType === 'PRV_PF' && productId === PRODUCT_IDS.IDPAY_MERCHANT;
   const isInvoicable = canInvoice(institutionType.toUpperCase(), productId);
 
   await fillUserBillingDataForm(
@@ -1153,7 +1153,7 @@ const executeStepBillingData = async (
 
   const confirmButton = screen.getByRole('button', { name: 'Continua' });
 
-  if (isPrivateMerchant) {
+  if (isPrivateMerchant || isPrivateMerchantPF) {
     expect(document.getElementById('recipientCode')).not.toBeInTheDocument();
     expect(document.getElementById('taxCodeInvoicing')).not.toBeInTheDocument();
     expect(document.getElementById('supportEmail')).not.toBeInTheDocument();

--- a/src/views/onboardingUser/components/StepSearchOnboardedParty.tsx
+++ b/src/views/onboardingUser/components/StepSearchOnboardedParty.tsx
@@ -147,6 +147,16 @@ function StepSearchOnboardedParty({ institutionType, selectedProduct, forward, b
             setDisabled={setDisabled}
             setIsSearchFieldSelected={() => {}}
             selectedProduct={selectedProduct}
+            selections={{
+              businessName: false,
+              aooCode: false,
+              uoCode: false,
+              reaCode: false,
+              taxCode: false,
+              personalTaxCode: false,
+              ivassCode: false,
+            }}
+            setSelections={() => {}}
           />
         </Grid>
         <Grid item xs={12} mt={2} mb={5}>

--- a/types.ts
+++ b/types.ts
@@ -264,7 +264,7 @@ export type InstitutionOnboardingInfoResource = {
   institution: InstitutionData;
 };
 
-export type InstitutionType = 'PA' | 'GSP' | 'SCP' | 'PT' | 'PSP' | 'SA' | 'AS' | 'PRV' | 'GPU' | 'SCEC';
+export type InstitutionType = 'PA' | 'GSP' | 'SCP' | 'PT' | 'PSP' | 'SA' | 'AS' | 'PRV' | 'GPU' | 'SCEC' | 'PRV_PF';
 
 export type ANACParty = {
   description: string;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
 
Updated various components to handle the new PRV_PF institution type, including:
  - Modified `stepSelectPartyByCF` to check for both private merchant and private merchant PF.
  - Enhanced `Autocomplete` and `PartyAdvancedSelect` components to accept and manage selections state.
  - Adjusted `PersonalAndBillingDataSection` to incorporate logic for PRV_PF in tax code and VAT number validations.
  - Updated `StepOnboardingFormData` and `StepSearchParty` to correctly process onboarding data for PRV_PF.
  - Refactored validation functions to include checks for PRV_PF.
  - Modified tests to cover scenarios involving PRV_PF.
  - Added new institution type to the `InstitutionType` type definition.

#### Motivation and Context

the new institutionType PRV_PF replace the old field soleTrarder that communicate to the BFF that the research it has been done by personalTaxCode

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.