### PR TITLE
[SELC-8603] Feat: trigger the qualtrics survey in the success page

### DIFF
--- a/src/services/onboardingSubmitServices.ts
+++ b/src/services/onboardingSubmitServices.ts
@@ -72,7 +72,8 @@ export const postOnboardingSubmit = async (
   pricingPlan: string | undefined,
   users: Array<UserOnCreate>,
   loggedUser: User | null,
-  aggregates?: Array<AggregateInstitution>
+  aggregates?: Array<AggregateInstitution>,
+  onSuccess?: () => void
   // eslint-disable-next-line sonarjs/cognitive-complexity
 ) => {
   setLoading(true);
@@ -177,6 +178,7 @@ export const postOnboardingSubmit = async (
       product_id: productId,
     });
     setOutcome(outcomeContent[outcome as keyof RequestOutcomeOptions]);
+    onSuccess?.();
   } else {
     const responseStatus = (response as AxiosError<Problem>).response?.status;
 

--- a/src/utils/qualtricsUtils.ts
+++ b/src/utils/qualtricsUtils.ts
@@ -1,0 +1,32 @@
+/* eslint-disable functional/immutable-data */
+declare global {
+  interface Window {
+    QSI?: {
+      API: {
+        unload: () => void;
+        load: () => void;
+        run: () => void;
+      };
+    };
+  }
+}
+
+type QualtricsData = {
+  institutionDescription: string;
+  productId: string;
+  institutionType: string;
+};
+
+export const triggerQualtricsIntercept = (data: QualtricsData): void => {
+  if (!window.QSI?.API) {
+    return;
+  }
+
+  (window as any).institutionDescription = data.institutionDescription;
+  (window as any).productId = data.productId;
+  (window as any).institutionType = data.institutionType;
+
+  window.QSI.API.unload();
+  window.QSI.API.load();
+  window.QSI.API.run();
+};

--- a/src/views/onboardingProduct/OnboardingProduct.tsx
+++ b/src/views/onboardingProduct/OnboardingProduct.tsx
@@ -43,6 +43,7 @@ import {
   isSendProduct,
   isTechPartner,
 } from '../../utils/institutionTypeUtils';
+import { triggerQualtricsIntercept } from '../../utils/qualtricsUtils';
 import { registerUnloadEvent, unregisterUnloadEvent } from '../../utils/unloadEvent-utils';
 import { createBackFunctions } from './components/backwards/backFunctions';
 import { createForwardFunctions } from './components/forwards/forwardFunctions';
@@ -235,7 +236,14 @@ function OnboardingProductComponent({ productId }: { productId: string }) {
       pricingPlan,
       isTechPartner(institutionType) ? usersWithoutLegal : users,
       user,
-      aggregates
+      aggregates,
+      () => {
+        triggerQualtricsIntercept({
+          institutionDescription: onboardingFormData?.businessName ?? '',
+          productId,
+          institutionType: institutionType ?? '',
+        });
+      }
     ).catch(() => {
       trackEvent('ONBOARDING_ADD_DELEGATE', {
         request_id: requestIdRef.current,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-8603] Feat: trigger the qualtrics survey in the success page
[SELC-8604] Feat: pass the embedded data (name of the party, productId and institutionType) as params

…d and institutionType) as params

<!--- Why is this change required? What problem does it solve? -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-8603]: https://pagopa.atlassian.net/browse/SELC-8603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SELC-8604]: https://pagopa.atlassian.net/browse/SELC-8604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ